### PR TITLE
Use db iterator directly in graph creation

### DIFF
--- a/multinet/multinet.py
+++ b/multinet/multinet.py
@@ -128,8 +128,7 @@ def create_graph(workspace, graph):
 
     # TODO: Update this with the proper JSON schema
     if errors:
-        payload = {"error": "Graph Validation Failed", "detail": errors}
-        return (payload, 400)
+        return (errors, "400 Graph Validation Failed")
 
     if db.create_graph(workspace, graph, node_tables, edge_table):
         return graph

--- a/multinet/multinet.py
+++ b/multinet/multinet.py
@@ -130,7 +130,5 @@ def create_graph(workspace, graph):
     if errors:
         return (errors, "400 Graph Validation Failed")
 
-    if db.create_graph(workspace, graph, node_tables, edge_table):
-        return graph
-    else:
-        return (graph, "409 Graph Already Exists")
+    db.create_graph(workspace, graph, node_tables, edge_table)
+    return graph

--- a/multinet/multinet.py
+++ b/multinet/multinet.py
@@ -87,13 +87,15 @@ def create_graph(workspace, graph):
     if missing:
         return (missing, "400 Missing Required Parameters")
 
-    errors = []
-
     loadedWorkspace = db.db(workspace)
+    if loadedWorkspace.has_graph(graph):
+        return (graph, "409 Graph Already Exists")
+
     existing_tables = set([x["name"] for x in loadedWorkspace.collections()])
     edges = loadedWorkspace.collection(edge_table).all()
 
     # Iterate through each edge and check for undefined tables
+    errors = []
     valid_tables = dict()
     invalid_tables = set()
     for edge in edges:


### PR DESCRIPTION
Fixes #111. This PR also introduces new code into the create_graph function. This code was intended to be merged into master before the move away from Girder, but got lost in the change. This also returns a response in direct contrast to #105. This is just temporary until that issue is resolved.