### PR TITLE
Ensure CSV files are consistent before table creation

### DIFF
--- a/multinet/uploaders/csv.py
+++ b/multinet/uploaders/csv.py
@@ -1,7 +1,7 @@
 """Multinet uploader for CSV files."""
 import csv
-from io import StringIO
 import re
+from io import StringIO
 
 from .. import db, api
 
@@ -47,6 +47,8 @@ def validate_csv(rows):
 
         if detail:
             return {"error": "syntax", "detail": detail}
+    else:
+        return {"error": "format", "detail": "Invalid header format"}
 
     return None
 


### PR DESCRIPTION
This is for updating the csv validation to ensure that files which aren't valid CSV aren't made into tables. Currently, I've added one commit which just returns an error if the file doesn't have a `_key` field, and also doesn't have `_from` and `_to` fields (and therefore can't be interpreted as a node table or an edge table). Certainly there's more we can do to validate the files, but I'm not sure what we _should_ do, hence the draft PR. This also deals with the backend side of #68, but doesn't add anything to the client.