### PR TITLE
Fix graph creation

### DIFF
--- a/client/src/components/GraphDialog.vue
+++ b/client/src/components/GraphDialog.vue
@@ -112,7 +112,7 @@ export default {
   methods: {
     async createGraph () {
       const { workspace, newGraph } = this;
-      const response = await api().post(`/multinet/workspace/${workspace}/graph/${newGraph}`, {
+      const response = await api().post(`/workspace/${workspace}/graph/${newGraph}`, {
         node_tables: this.graphNodeTables,
         edge_table: this.graphEdgeTable,
       });

--- a/multinet/api.py
+++ b/multinet/api.py
@@ -148,7 +148,7 @@ def create_graph(workspace, graph, node_tables=None, edge_table=None):
 
     # TODO: Update this with the proper JSON schema
     if errors:
-        return (errors, "400 Graph Validation Failed")
+        return ({"errors": errors}, "400 Graph Validation Failed")
 
     db.create_graph(workspace, graph, node_tables, edge_table)
     return graph

--- a/test/data/membership_invalid_keys.csv
+++ b/test/data/membership_invalid_keys.csv
@@ -1,0 +1,4 @@
+_from,_to
+members/soup,clubs/0
+members/12,clubs/feet
+members/foo,clubs/bar


### PR DESCRIPTION
One of the changes here wraps the `errors` list with a dict. I'm not sure how it got past us before, but at least on my local, when creating a graph (after fixing the issue addressed on the client) the server throws an error, stating that lists can't be directly returned. Lmk if you think there's a better way to deal with this @waxlamp.