### PR TITLE
Add functionality to catch many upload problems at once and return them all

### DIFF
--- a/test/data/clubs_broken_encoding.csv
+++ b/test/data/clubs_broken_encoding.csv
@@ -1,0 +1,8 @@
+_key,name
+0,St Andrews Lodge
+?,Loyal Nine
+2,North Caucus
+3,Long Room Club
+4,?
+5,Boston Committee
+6,London Enemies


### PR DESCRIPTION
Right now this just deals with the csv uploader. Looks like some of this work overlaps with @AlmightyYakob but expands functionality to catch many errors in one pass