### PR TITLE
Fix pre-commit hooks to be in sync with CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,4 +5,6 @@ repos:
     - id: flake8
       additional_dependencies: ['flake8-black', 'flake8-bugbear', 'flake8-docstrings', 'flake8-quotes']
       args: [--config=.flake8]
-      exclude: (__pycache__)|(build)|(^scripts)
+      # Need to have this both here and in flake8, because pre-commit
+      # doesn't read the `exclude` config option in .flake8
+      exclude: (__pycache__)|(^build)|(^scripts/)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,8 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: stable
-    hooks:
-    - id: black
-      language_version: python3.7
-      args: [--check]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.2.3
     hooks:
     - id: flake8
+      additional_dependencies: ['flake8-black', 'flake8-bugbear', 'flake8-docstrings', 'flake8-quotes']
       args: [--config=.flake8]
+      exclude: (__pycache__)|(build)|(^scripts)


### PR DESCRIPTION
This solves the issue we had discussed, regarding the pre-commit hooks and the CI tests being out of sync. This also removes the need for the black hook entirely, as we were only running it with `--check`, and that's what flake8-black does. You'll notice there's an extra `excludes` field being used, which uses regex. Ideally, pre-commit would read this from the `.flake8` , but the flag that controls this is actually ignored, so this is necessary. However, the hook does read the other options from `.flake8`.