### PR TITLE
Fix sorting of graphs and tables in workspace

### DIFF
--- a/multinet/resolvers/workspace.py
+++ b/multinet/resolvers/workspace.py
@@ -15,12 +15,18 @@ def name(workspace, info):
 
 def tables(workspace, info):
     """Return the tables within a workspace."""
-    return [Table(workspace, table) for table in db.workspace_tables(workspace)]
+    return sorted(
+        [Table(workspace, table) for table in db.workspace_tables(workspace)],
+        key=lambda table: table.table,
+    )
 
 
 def graphs(workspace, info):
     """Return the graphs within a workspace."""
-    return [Graph(workspace, graph) for graph in db.workspace_graphs(workspace)]
+    return sorted(
+        [Graph(workspace, graph) for graph in db.workspace_graphs(workspace)],
+        key=lambda graph: graph.graph,
+    )
 
 
 def add_resolvers(schema):


### PR DESCRIPTION
Fixes #142. Something to note, it seems like there's some duplicate code in the resolvers, for example between `query.py` and `workspace.py`. However, since I think @waxlamp will be removing graphql soon, I didn't pursue a comprehensive change.