### PR TITLE
Add the adjacency matrix app to the apps list

### DIFF
--- a/client/src/appregistry.json
+++ b/client/src/appregistry.json
@@ -1,6 +1,10 @@
 [
     {
-        "name": "nodelink",
+        "name": "Nodelink",
         "url": "http://multinet.app/nodelink"
+    },
+    {
+        "name": "Adjacency Matrix",
+        "url": "http://multinet.app/adjmatrix"
     }
 ]


### PR DESCRIPTION
Closes #190. Adds the adjacency matrix as an external app. It will likely be removed and become a built in app at some point