### PR TITLE
Use multinetjs in client application

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,9 +11,9 @@
     "axios": "^0.18.1",
     "core-js": "^2.6.5",
     "material-design-icons-iconfont": "^5.0.1",
-    "vue": "^2.6.6",
-    "vue-router": "^3.0.2",
+    "multinet": "^0.1.0",
     "vue": "^2.6.10",
+    "vue-router": "^3.0.2",
     "vuetify": "^2.0.5"
   },
   "devDependencies": {

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,15 +1,9 @@
-import axios from 'axios';
-
 import { multinetApi } from 'multinet';
 
 function getApiRoot() {
   return `${window.location.origin}/api`;
 }
 
-export default function() {
-  return axios.create({
-    baseURL: getApiRoot(),
-  });
-}
+const api = multinetApi(getApiRoot());
 
-export const apix = multinetApi(getApiRoot());
+export default api;

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+import { multinetApi } from 'multinet';
+
 function getApiRoot() {
   return `${window.location.origin}/api`;
 }
@@ -9,3 +11,5 @@ export default function() {
     baseURL: getApiRoot(),
   });
 }
+
+export const apix = multinetApi(getApiRoot());

--- a/client/src/components/GraphDialog.vue
+++ b/client/src/components/GraphDialog.vue
@@ -87,7 +87,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import api from '@/api';
+import api, { apix } from '@/api';
 
 export default Vue.extend({
   name: 'GraphDialog',
@@ -114,10 +114,12 @@ export default Vue.extend({
   methods: {
     async createGraph() {
       const { workspace, newGraph } = this;
-      const response = await api().post(`/workspaces/${workspace}/graph/${newGraph}`, {
-        node_tables: this.graphNodeTables,
-        edge_table: this.graphEdgeTable,
-      });
+
+      if (this.graphEdgeTable === null) {
+        throw new Error('this.graphEdgeTable must not be null');
+      }
+
+      const response = await apix.createGraph(workspace, newGraph, this.graphNodeTables, this.graphEdgeTable);
 
       if (!response) {
         const message = `Graph "${this.newGraph}" already exists.`;

--- a/client/src/components/GraphDialog.vue
+++ b/client/src/components/GraphDialog.vue
@@ -119,7 +119,10 @@ export default Vue.extend({
         throw new Error('this.graphEdgeTable must not be null');
       }
 
-      const response = await api.createGraph(workspace, newGraph, this.graphNodeTables, this.graphEdgeTable);
+      const response = await api.createGraph(workspace, newGraph, {
+        nodeTables: this.graphNodeTables,
+        edgeTable: this.graphEdgeTable,
+      });
 
       if (!response) {
         const message = `Graph "${this.newGraph}" already exists.`;

--- a/client/src/components/GraphDialog.vue
+++ b/client/src/components/GraphDialog.vue
@@ -87,7 +87,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import api, { apix } from '@/api';
+import api from '@/api';
 
 export default Vue.extend({
   name: 'GraphDialog',
@@ -119,7 +119,7 @@ export default Vue.extend({
         throw new Error('this.graphEdgeTable must not be null');
       }
 
-      const response = await apix.createGraph(workspace, newGraph, this.graphNodeTables, this.graphEdgeTable);
+      const response = await api.createGraph(workspace, newGraph, this.graphNodeTables, this.graphEdgeTable);
 
       if (!response) {
         const message = `Graph "${this.newGraph}" already exists.`;

--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -86,7 +86,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import api, { apix } from '@/api';
+import api from '@/api';
 import WorkspaceDialog from '@/components/WorkspaceDialog.vue';
 
 export default Vue.extend({
@@ -116,7 +116,7 @@ export default Vue.extend({
     },
   },
   async created() {
-    this.workspaces = await apix.workspaces();
+    this.workspaces = await api.workspaces();
   },
 });
 </script>

--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -86,7 +86,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import api from '@/api';
+import api, { apix } from '@/api';
 import WorkspaceDialog from '@/components/WorkspaceDialog.vue';
 
 export default Vue.extend({
@@ -116,8 +116,7 @@ export default Vue.extend({
     },
   },
   async created() {
-    const response = await api().get('/workspaces');
-    this.workspaces = response.data;
+    this.workspaces = await apix.workspaces();
   },
 });
 </script>

--- a/client/src/components/TableDialog.vue
+++ b/client/src/components/TableDialog.vue
@@ -84,9 +84,10 @@
 </template>
 
 <script lang="ts">
+import { TableType } from 'multinet';
 import Vue from 'vue';
 
-import api from '@/api';
+import api, { apix } from '@/api';
 import { FileType } from '@/types';
 
 export default Vue.extend({
@@ -130,16 +131,14 @@ export default Vue.extend({
     },
 
     async createTable() {
-      const queryType = this.types[this.selectedType as string].queryCall;
+      const queryType: TableType = this.types[this.selectedType as string].queryCall;
       try {
-        await api().post(`/${queryType}/${this.workspace}/${this.newTable}`,
-        this.file,
-        {
-          headers: {
-            'Content-Type': 'text/plain',
-          },
-        },
-        );
+        if (this.file === null) {
+          throw new Error('this.file must not be null');
+        }
+
+        await apix.uploadTable(queryType, this.workspace, this.newTable, this.file);
+
         this.tableCreationError = null;
         this.$emit('success');
         this.tableDialog = false;

--- a/client/src/components/TableDialog.vue
+++ b/client/src/components/TableDialog.vue
@@ -84,7 +84,7 @@
 </template>
 
 <script lang="ts">
-import { DataType } from 'multinet';
+import { UploadType } from 'multinet';
 import Vue from 'vue';
 
 import api from '@/api';
@@ -131,7 +131,7 @@ export default Vue.extend({
     },
 
     async createTable() {
-      const queryType: DataType = this.types[this.selectedType as string].queryCall;
+      const queryType: UploadType = this.types[this.selectedType as string].queryCall;
       try {
         if (this.file === null) {
           throw new Error('this.file must not be null');

--- a/client/src/components/TableDialog.vue
+++ b/client/src/components/TableDialog.vue
@@ -87,7 +87,7 @@
 import { DataType } from 'multinet';
 import Vue from 'vue';
 
-import api, { apix } from '@/api';
+import api from '@/api';
 import { FileType } from '@/types';
 
 export default Vue.extend({
@@ -137,7 +137,7 @@ export default Vue.extend({
           throw new Error('this.file must not be null');
         }
 
-        await apix.uploadTable(queryType, this.workspace, this.newTable, this.file);
+        await api.uploadTable(queryType, this.workspace, this.newTable, this.file);
 
         this.tableCreationError = null;
         this.$emit('success');

--- a/client/src/components/TableDialog.vue
+++ b/client/src/components/TableDialog.vue
@@ -131,13 +131,16 @@ export default Vue.extend({
     },
 
     async createTable() {
-      const queryType: DataType= this.types[this.selectedType as string].queryCall;
+      const queryType: DataType = this.types[this.selectedType as string].queryCall;
       try {
         if (this.file === null) {
           throw new Error('this.file must not be null');
         }
 
-        await api.uploadTable(queryType, this.workspace, this.newTable, this.file);
+        await api.uploadTable(this.workspace, this.newTable, {
+          type: queryType,
+          data: this.file,
+        });
 
         this.tableCreationError = null;
         this.$emit('success');

--- a/client/src/components/TableDialog.vue
+++ b/client/src/components/TableDialog.vue
@@ -84,7 +84,7 @@
 </template>
 
 <script lang="ts">
-import { TableType } from 'multinet';
+import { DataType } from 'multinet';
 import Vue from 'vue';
 
 import api, { apix } from '@/api';
@@ -131,7 +131,7 @@ export default Vue.extend({
     },
 
     async createTable() {
-      const queryType: TableType = this.types[this.selectedType as string].queryCall;
+      const queryType: DataType= this.types[this.selectedType as string].queryCall;
       try {
         if (this.file === null) {
           throw new Error('this.file must not be null');

--- a/client/src/components/WorkspaceDialog.vue
+++ b/client/src/components/WorkspaceDialog.vue
@@ -60,7 +60,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import api, { apix } from '@/api';
+import api from '@/api';
 
 export default Vue.extend({
   data() {
@@ -75,7 +75,7 @@ export default Vue.extend({
   methods: {
     async create() {
       if (this.newWorkspace) {
-        const response = apix.createWorkspace(this.newWorkspace);
+        const response = api.createWorkspace(this.newWorkspace);
 
         if (response) {
           this.$router.push(`/workspaces/${this.newWorkspace}`);

--- a/client/src/components/WorkspaceDialog.vue
+++ b/client/src/components/WorkspaceDialog.vue
@@ -60,7 +60,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import api from '@/api';
+import api, { apix } from '@/api';
 
 export default Vue.extend({
   data() {
@@ -75,7 +75,7 @@ export default Vue.extend({
   methods: {
     async create() {
       if (this.newWorkspace) {
-        const response = await api().post(`/workspaces/${this.newWorkspace}`);
+        const response = apix.createWorkspace(this.newWorkspace);
 
         if (response) {
           this.$router.push(`/workspaces/${this.newWorkspace}`);

--- a/client/src/components/WorkspaceDialog.vue
+++ b/client/src/components/WorkspaceDialog.vue
@@ -75,7 +75,7 @@ export default Vue.extend({
   methods: {
     async create() {
       if (this.newWorkspace) {
-        const response = api.createWorkspace(this.newWorkspace);
+        const response = await api.createWorkspace(this.newWorkspace);
 
         if (response) {
           this.$router.push(`/workspaces/${this.newWorkspace}`);

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,3 +1,5 @@
+import { TableType } from 'multinet';
+
 export interface KeyValue {
   key: string;
   value: any;
@@ -12,7 +14,7 @@ export interface TableRow {
 
 export interface FileType {
   extension: string[];
-  queryCall: string;
+  queryCall: TableType;
 }
 
 export interface FileTypeTable {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,4 +1,4 @@
-import { DataType } from 'multinet';
+import { UploadType } from 'multinet';
 
 export interface KeyValue {
   key: string;

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,4 +1,4 @@
-import { TableType } from 'multinet';
+import { DataType } from 'multinet';
 
 export interface KeyValue {
   key: string;
@@ -14,7 +14,7 @@ export interface TableRow {
 
 export interface FileType {
   extension: string[];
-  queryCall: TableType;
+  queryCall: DataType;
 }
 
 export interface FileTypeTable {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -14,7 +14,7 @@ export interface TableRow {
 
 export interface FileType {
   extension: string[];
-  queryCall: DataType;
+  queryCall: UploadType;
 }
 
 export interface FileTypeTable {

--- a/client/src/views/GraphDetail.vue
+++ b/client/src/views/GraphDetail.vue
@@ -51,7 +51,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import api from '@/api';
+import api, { apix } from '@/api';
 
 export default Vue.extend({
   name: 'GraphDetail',
@@ -88,11 +88,8 @@ export default Vue.extend({
   },
   methods: {
     async update() {
-      let response = await api().get(`/workspaces/${this.workspace}/graphs/${this.graph}`);
-      const graph = response.data;
-
-      response = await api().get(`/workspaces/${this.workspace}/graphs/${this.graph}/nodes?offset=${this.offset}&limit=${this.limit}`);
-      const nodes = response.data;
+      const graph = await apix.graph(this.workspace, this.graph);
+      const nodes = await apix.nodes(this.workspace, this.graph, this.offset, this.limit);
 
       this.nodeTypes = graph.nodeTables;
       this.edgeTypes = [graph.edgeTable];

--- a/client/src/views/GraphDetail.vue
+++ b/client/src/views/GraphDetail.vue
@@ -51,7 +51,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import api, { apix } from '@/api';
+import api from '@/api';
 
 export default Vue.extend({
   name: 'GraphDetail',
@@ -88,8 +88,8 @@ export default Vue.extend({
   },
   methods: {
     async update() {
-      const graph = await apix.graph(this.workspace, this.graph);
-      const nodes = await apix.nodes(this.workspace, this.graph, this.offset, this.limit);
+      const graph = await api.graph(this.workspace, this.graph);
+      const nodes = await api.nodes(this.workspace, this.graph, this.offset, this.limit);
 
       this.nodeTypes = graph.nodeTables;
       this.edgeTypes = [graph.edgeTable];

--- a/client/src/views/GraphDetail.vue
+++ b/client/src/views/GraphDetail.vue
@@ -89,7 +89,10 @@ export default Vue.extend({
   methods: {
     async update() {
       const graph = await api.graph(this.workspace, this.graph);
-      const nodes = await api.nodes(this.workspace, this.graph, this.offset, this.limit);
+      const nodes = await api.nodes(this.workspace, this.graph, {
+        offset: this.offset,
+        limit: this.limit,
+      });
 
       this.nodeTypes = graph.nodeTables;
       this.edgeTypes = [graph.edgeTable];

--- a/client/src/views/NodeDetail.vue
+++ b/client/src/views/NodeDetail.vue
@@ -53,7 +53,7 @@
 import Vue from 'vue';
 import { Edge } from 'multinet';
 
-import api, { apix } from '@/api';
+import api from '@/api';
 import { KeyValue } from '@/types';
 
 interface EdgeRecord {
@@ -114,9 +114,9 @@ export default Vue.extend({
   },
   methods: {
     async update() {
-      const attributes = await apix.attributes(this.workspace, this.graph, `${this.type}/${this.node}`);
-      const incoming = await apix.edges(this.workspace, this.graph, `${this.type}/${this.node}`, 'incoming', this.offsetIncoming, this.pageCount);
-      const outgoing = await apix.edges(this.workspace, this.graph, `${this.type}/${this.node}`, 'outgoing', this.offsetOutgoing, this.pageCount);
+      const attributes = await api.attributes(this.workspace, this.graph, `${this.type}/${this.node}`);
+      const incoming = await api.edges(this.workspace, this.graph, `${this.type}/${this.node}`, 'incoming', this.offsetIncoming, this.pageCount);
+      const outgoing = await api.edges(this.workspace, this.graph, `${this.type}/${this.node}`, 'outgoing', this.offsetOutgoing, this.pageCount);
 
       this.attributes = Object.entries(attributes).map(([key, value]) => ({
         key,

--- a/client/src/views/NodeDetail.vue
+++ b/client/src/views/NodeDetail.vue
@@ -115,8 +115,16 @@ export default Vue.extend({
   methods: {
     async update() {
       const attributes = await api.attributes(this.workspace, this.graph, `${this.type}/${this.node}`);
-      const incoming = await api.edges(this.workspace, this.graph, `${this.type}/${this.node}`, 'incoming', this.offsetIncoming, this.pageCount);
-      const outgoing = await api.edges(this.workspace, this.graph, `${this.type}/${this.node}`, 'outgoing', this.offsetOutgoing, this.pageCount);
+      const incoming = await api.edges(this.workspace, this.graph, `${this.type}/${this.node}`, {
+        direction: 'incoming',
+        offset: this.offsetIncoming,
+        limit: this.pageCount,
+      });
+      const outgoing = await api.edges(this.workspace, this.graph, `${this.type}/${this.node}`, {
+        direction: 'outgoing',
+        offset: this.offsetOutgoing,
+        limit: this.pageCount,
+      });
 
       this.attributes = Object.entries(attributes).map(([key, value]) => ({
         key,

--- a/client/src/views/TableDetail.vue
+++ b/client/src/views/TableDetail.vue
@@ -92,7 +92,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import api from '@/api';
+import api, { apix } from '@/api';
 import { KeyValue, TableRow } from '@/types';
 
 export default Vue.extend({
@@ -111,20 +111,22 @@ export default Vue.extend({
       return index % 2 === 0 ? 'even-row' : 'odd-row';
     },
     async update() {
-      let response = await api().get(`/workspaces/${this.workspace}/tables/${this.table}?headers=true&rows=true`);
-      const result: TableRow[] = response.data;
+      const result = await apix.table(this.workspace, this.table);
 
       const rowKeys: KeyValue[][] = [];
       let headers: Array<keyof TableRow> = [];
       if (result) {
         result.forEach((row) => {
           const rowData: KeyValue[] = [];
-          Object.keys(row).filter((k) => k !== '_rev').forEach((key) => {
-            rowData.push({
-              key,
-              value: row[key],
+          Object.entries(row)
+            .filter(([key, value]) => key !== '_rev')
+            .forEach(([key, value]) => {
+              rowData.push({
+                key,
+                value,
+              });
             });
-          });
+
           rowKeys.push(rowData);
         });
 
@@ -135,7 +137,7 @@ export default Vue.extend({
       this.headers = headers;
 
       // Roni to convert these lines to computed function
-      response = await api().get(`workspaces/${this.workspace}/tables?type=all`);
+      const response = await api().get(`workspaces/${this.workspace}/tables?type=all`);
       this.tables = response.data;
     },
   },

--- a/client/src/views/TableDetail.vue
+++ b/client/src/views/TableDetail.vue
@@ -137,7 +137,9 @@ export default Vue.extend({
       this.headers = headers;
 
       // Roni to convert these lines to computed function
-      this.tables = await api.tables(this.workspace, 'all');
+      this.tables = await api.tables(this.workspace, {
+        type: 'all',
+      });
     },
   },
   watch: {

--- a/client/src/views/TableDetail.vue
+++ b/client/src/views/TableDetail.vue
@@ -92,7 +92,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import api, { apix } from '@/api';
+import api from '@/api';
 import { KeyValue, TableRow } from '@/types';
 
 export default Vue.extend({
@@ -111,7 +111,7 @@ export default Vue.extend({
       return index % 2 === 0 ? 'even-row' : 'odd-row';
     },
     async update() {
-      const result = await apix.table(this.workspace, this.table);
+      const result = await api.table(this.workspace, this.table);
 
       const rowKeys: KeyValue[][] = [];
       let headers: Array<keyof TableRow> = [];
@@ -137,7 +137,7 @@ export default Vue.extend({
       this.headers = headers;
 
       // Roni to convert these lines to computed function
-      this.tables = await apix.tables(this.workspace, 'all');
+      this.tables = await api.tables(this.workspace, 'all');
     },
   },
   watch: {

--- a/client/src/views/TableDetail.vue
+++ b/client/src/views/TableDetail.vue
@@ -102,7 +102,7 @@ export default Vue.extend({
     return {
       rowKeys: [] as KeyValue[][],
       headers: [] as Array<keyof TableRow>,
-      tables: [],
+      tables: [] as string[],
       editing: false,
     };
   },
@@ -137,8 +137,7 @@ export default Vue.extend({
       this.headers = headers;
 
       // Roni to convert these lines to computed function
-      const response = await api().get(`workspaces/${this.workspace}/tables?type=all`);
-      this.tables = response.data;
+      this.tables = await apix.tables(this.workspace, 'all');
     },
   },
   watch: {

--- a/client/src/views/WorkspaceDetail.vue
+++ b/client/src/views/WorkspaceDetail.vue
@@ -173,8 +173,8 @@ export default Vue.extend({
   methods: {
     async update() {
       // Get lists of node and edge tables.
-      const nodeTables = await api.tables(this.workspace, 'node');
-      const edgeTables = await api.tables(this.workspace, 'edge');
+      const nodeTables = await api.tables(this.workspace, { type: 'node' });
+      const edgeTables = await api.tables(this.workspace, { type: 'edge' });
 
       this.tables = nodeTables.concat(edgeTables);
       this.nodeTables = nodeTables;

--- a/client/src/views/WorkspaceDetail.vue
+++ b/client/src/views/WorkspaceDetail.vue
@@ -137,7 +137,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import api, { apix } from '@/api';
+import api from '@/api';
 import ItemPanel from '@/components/ItemPanel.vue';
 import GraphDialog from '@/components/GraphDialog.vue';
 import TableDialog from '@/components/TableDialog.vue';
@@ -173,15 +173,15 @@ export default Vue.extend({
   methods: {
     async update() {
       // Get lists of node and edge tables.
-      const nodeTables = await apix.tables(this.workspace, 'node');
-      const edgeTables = await apix.tables(this.workspace, 'edge');
+      const nodeTables = await api.tables(this.workspace, 'node');
+      const edgeTables = await api.tables(this.workspace, 'edge');
 
       this.tables = nodeTables.concat(edgeTables);
       this.nodeTables = nodeTables;
       this.edgeTables = edgeTables;
 
       // Get list of graphs.
-      this.graphs = await apix.graphs(this.workspace);
+      this.graphs = await api.graphs(this.workspace);
     },
   },
   created() {

--- a/client/src/views/WorkspaceDetail.vue
+++ b/client/src/views/WorkspaceDetail.vue
@@ -137,7 +137,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import api from '@/api';
+import api, { apix } from '@/api';
 import ItemPanel from '@/components/ItemPanel.vue';
 import GraphDialog from '@/components/GraphDialog.vue';
 import TableDialog from '@/components/TableDialog.vue';
@@ -162,7 +162,7 @@ export default Vue.extend({
       tables: [],
       nodeTables: [],
       edgeTables: [],
-      graphs: [],
+      graphs: [] as string[],
     };
   },
   watch: {
@@ -184,10 +184,7 @@ export default Vue.extend({
       this.edgeTables = edgeTables;
 
       // Get list of graphs.
-      response = await api().get(`workspaces/${this.workspace}/graphs`);
-      const graphs = response.data;
-
-      this.graphs = graphs;
+      this.graphs = await apix.graphs(this.workspace);
     },
   },
   created() {

--- a/client/src/views/WorkspaceDetail.vue
+++ b/client/src/views/WorkspaceDetail.vue
@@ -159,9 +159,9 @@ export default Vue.extend({
         newick: {extension: ['phy', 'tree'], queryCall: 'newick'},
         nested_json: {extension: ['json'], queryCall: 'nested_json'},
       } as FileTypeTable,
-      tables: [],
-      nodeTables: [],
-      edgeTables: [],
+      tables: [] as string[],
+      nodeTables: [] as string[],
+      edgeTables: [] as string[],
       graphs: [] as string[],
     };
   },
@@ -173,11 +173,8 @@ export default Vue.extend({
   methods: {
     async update() {
       // Get lists of node and edge tables.
-      let response = await api().get(`workspaces/${this.workspace}/tables?type=node`);
-      const nodeTables = response.data;
-
-      response = await api().get(`workspaces/${this.workspace}/tables?type=edge`);
-      const edgeTables = response.data;
+      const nodeTables = await apix.tables(this.workspace, 'node');
+      const edgeTables = await apix.tables(this.workspace, 'edge');
 
       this.tables = nodeTables.concat(edgeTables);
       this.nodeTables = nodeTables;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1482,6 +1482,14 @@ axios@^0.18.1:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
 
+axios@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
+  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
+
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -5242,6 +5250,13 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
+
+multinet@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.1.0.tgz#27c1e0febaf04db294dbbf6f6abe5dd618ea111c"
+  integrity sha512-aLHr9k7nMbLG4zoSp6FhtYu0daZfz4jlk3XDVj2eCTHcbkEYpZdDtZkGFwxqMPgDViLMgZqlcQbedCQ24Bx99Q==
+  dependencies:
+    axios "^0.19.0"
 
 mz@^2.4.0:
   version "2.7.0"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,6 @@ version: '3'
 services:
   arangodb:
     image: arangodb/arangodb:3.4.3
-    container_name: arangodb
     ports:
       - "${ARANGO_PORT:-8529}:8529"
     environment:

--- a/multinetjs/LICENSE
+++ b/multinetjs/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/multinetjs/README.md
+++ b/multinetjs/README.md
@@ -1,0 +1,4 @@
+# multinetjs
+
+A TypeScript library for interacting with
+[MultiNet](https://github.com/multinet-app/multinet) servers.

--- a/multinetjs/package.json
+++ b/multinetjs/package.json
@@ -4,6 +4,20 @@
   "description": "Multinet client library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist/client.d.ts",
+    "dist/client.d.ts.map",
+    "dist/client.js",
+    "dist/client.js.map",
+    "dist/index.d.ts",
+    "dist/index.d.ts.map",
+    "dist/index.js",
+    "dist/index.js.map",
+    "dist/types.d.ts",
+    "dist/types.d.ts.map",
+    "dist/types.js",
+    "dist/types.js.map"
+  ],
   "scripts": {
     "start": "tsc -w",
     "build": "tsc",

--- a/multinetjs/src/index.ts
+++ b/multinetjs/src/index.ts
@@ -23,34 +23,32 @@ export interface EdgesSpec {
 
 export type TableType = 'all' | 'node' | 'edge';
 
-export type DataType = 'csv' | 'nested_json' | 'newick';
+export type UploadType = 'csv' | 'nested_json' | 'newick';
 
 export type Direction = 'all' | 'incoming' | 'outgoing';
 
-interface TablesOptionsSpec {
+export interface TablesOptionsSpec {
   type?: TableType;
 }
 
-interface OffsetLimitSpec {
+export interface OffsetLimitSpec {
   offset?: number;
   limit?: number;
 }
 
-type EdgesOptionsSpec = OffsetLimitSpec & {
-  direction: Direction;
+export type EdgesOptionsSpec = OffsetLimitSpec & {
+  direction?: Direction;
 }
 
-interface UploadTableOptionsSpec {
-  type: DataType;
+export interface UploadTableOptionsSpec {
+  type: UploadType;
   data: string | File;
 }
 
-interface CreateGraphOptionsSpec {
+export interface CreateGraphOptionsSpec {
   nodeTables: string[];
   edgeTable: string;
-}
-
-function fileToText(file: File): Promise<string> {
+}function fileToText(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = (e) => {

--- a/multinetjs/src/index.ts
+++ b/multinetjs/src/index.ts
@@ -38,7 +38,7 @@ export interface OffsetLimitSpec {
 
 export type EdgesOptionsSpec = OffsetLimitSpec & {
   direction?: Direction;
-}
+};
 
 export interface UploadTableOptionsSpec {
   type: UploadType;
@@ -48,7 +48,9 @@ export interface UploadTableOptionsSpec {
 export interface CreateGraphOptionsSpec {
   nodeTables: string[];
   edgeTable: string;
-}function fileToText(file: File): Promise<string> {
+}
+
+function fileToText(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = (e) => {
@@ -116,23 +118,23 @@ class MultinetAPI {
     return this.client.post(`/workspaces/${workspace}`);
   }
 
-  public async uploadTable(workspace: string, table: string, { type, data }: UploadTableOptionsSpec): Promise<Array<{}>> {
+  public async uploadTable(workspace: string, table: string, options: UploadTableOptionsSpec): Promise<Array<{}>> {
     let text;
-    if (typeof data === "string") {
-      text = data;
+    if (typeof options.data === 'string') {
+      text = options.data;
     } else {
-      text = await fileToText(data);
+      text = await fileToText(options.data);
     }
 
-    return this.client.post(`/${type}/${workspace}/${table}`, text, {
+    return this.client.post(`/${options.type}/${workspace}/${table}`, text, {
       'Content-Type': 'text/plain',
     });
   }
 
-  public createGraph(workspace: string, graph: string, { nodeTables, edgeTable }: CreateGraphOptionsSpec): Promise<string> {
+  public createGraph(workspace: string, graph: string, options: CreateGraphOptionsSpec): Promise<string> {
     return this.client.post(`/workspaces/${workspace}/graph/${graph}`, {
-      node_tables: nodeTables,
-      edge_table: edgeTable,
+      node_tables: options.nodeTables,
+      edge_table: options.edgeTable,
     });
   }
 }

--- a/multinetjs/src/index.ts
+++ b/multinetjs/src/index.ts
@@ -21,7 +21,9 @@ export interface EdgesSpec {
   edges: Edge[];
 }
 
-export type TableType = 'csv' | 'nested_json' | 'newick';
+export type TableType = 'all' | 'node' | 'edge';
+
+export type DataType = 'csv' | 'nested_json' | 'newick';
 
 export type Direction = 'all' | 'incoming' | 'outgoing';
 
@@ -61,8 +63,8 @@ class MultinetAPI {
     return this.client.get(`workspaces/${workspace}`);
   }
 
-  public tables(workspace: string): Promise<string[]> {
-    return this.client.get(`workspaces/${workspace}/tables`);
+  public tables(workspace: string, type: TableType = 'all'): Promise<string[]> {
+    return this.client.get(`workspaces/${workspace}/tables?type=${type}`);
   }
 
   public table(workspace: string, table: string, offset: number = 0, limit: number = 30): Promise<Array<{}>> {
@@ -109,7 +111,7 @@ class MultinetAPI {
     return this.client.post(`/workspaces/${workspace}`);
   }
 
-  public async uploadTable(type: TableType, workspace: string, table: string, data: string | File): Promise<Array<{}>> {
+  public async uploadTable(type: DataType, workspace: string, table: string, data: string | File): Promise<Array<{}>> {
     let text;
     if (typeof data === "string") {
       text = data;

--- a/multinetjs/test/multinet.test.js
+++ b/multinetjs/test/multinet.test.js
@@ -105,6 +105,23 @@ test('multinet test', async (t) => {
   }
 
   try {
+    let allTables = await api.tables(newWorkspace);
+    let allTables2 = await api.tables(newWorkspace, 'all');
+    allTables.sort();
+    allTables2.sort();
+    t.deepEqual(allTables, ['clubs', 'members', 'membership'], 'tables() reports all tables');
+    t.deepEqual(allTables, allTables2, 'omitting `type` parameter returns all tables');
+
+    const nodeTables = await api.tables(newWorkspace, 'node');
+    t.deepEqual(nodeTables, ['clubs', 'members'], 'setting `type` to "node" reports node tables');
+
+    const edgeTables = await api.tables(newWorkspace, 'edge');
+    t.deepEqual(edgeTables, ['membership'], 'setting `type` to "edge" reports edge tables');
+  } catch(e) {
+    t.fail(failMessage('api.tables()', e));
+  }
+
+  try {
     const result = await api.graphs(newWorkspace);
     t.deepEqual(result, [], 'new workspace has no graphs');
   } catch(e) {

--- a/multinetjs/test/multinet.test.js
+++ b/multinetjs/test/multinet.test.js
@@ -63,7 +63,10 @@ test('multinet test', async (t) => {
   }
 
   try {
-    const result = await api.uploadTable('csv', newWorkspace, 'members', membersText);
+    const result = await api.uploadTable(newWorkspace, 'members', {
+      type: 'csv',
+      data: membersText,
+    });
     t.deepEqual(result, { count: 254 }, 'server reports the correct number of lines added to database');
   } catch(e) {
     t.fail(failMessage('api.uploadTable()', e));
@@ -80,23 +83,38 @@ test('multinet test', async (t) => {
     let members = await api.table(newWorkspace, 'members');
     t.equal(members.length, 30, 'asking for table yields 30 items');
 
-    members = await api.table(newWorkspace, 'members', 0, 50);
+    members = await api.table(newWorkspace, 'members', {
+      offset: 0,
+      limit: 50,
+    });
     t.equal(members.length, 50, 'asking table for 50 items yields 50 items');
 
-    members = await api.table(newWorkspace, 'members', 0, 254);
+    members = await api.table(newWorkspace, 'members', {
+      offset: 0,
+      limit: 254,
+    });
     t.equal(members.length, 254, 'asking table for all items yields 254 items');
 
-    members = await api.table(newWorkspace, 'members', 0, 300);
+    members = await api.table(newWorkspace, 'members', {
+      offset: 0,
+      limit: 300,
+    });
     t.equal(members.length, 254, 'asking table for more than 254 items yields 254 items');
   } catch(e) {
     t.fail(failMessage(`api.table("${newWorkspace}", "members")`, e));
   }
 
   try {
-    let result = await api.uploadTable('csv', newWorkspace, 'clubs', clubsText);
+    let result = await api.uploadTable(newWorkspace, 'clubs', {
+      type: 'csv',
+      data: clubsText,
+    });
     t.deepEqual(result, { count: 7 }, 'upload clubs data');
 
-    result = await api.uploadTable('csv', newWorkspace, 'membership', membershipText);
+    result = await api.uploadTable(newWorkspace, 'membership', {
+      type: 'csv',
+      data: membershipText,
+    });
     t.deepEqual(result, { count: 319 }, 'upload membership data');
 
     result = await api.tables(newWorkspace);
@@ -106,16 +124,22 @@ test('multinet test', async (t) => {
 
   try {
     let allTables = await api.tables(newWorkspace);
-    let allTables2 = await api.tables(newWorkspace, 'all');
+    let allTables2 = await api.tables(newWorkspace, {
+      type: 'all',
+    });
     allTables.sort();
     allTables2.sort();
     t.deepEqual(allTables, ['clubs', 'members', 'membership'], 'tables() reports all tables');
     t.deepEqual(allTables, allTables2, 'omitting `type` parameter returns all tables');
 
-    const nodeTables = await api.tables(newWorkspace, 'node');
+    const nodeTables = await api.tables(newWorkspace, {
+      type: 'node',
+    });
     t.deepEqual(nodeTables, ['clubs', 'members'], 'setting `type` to "node" reports node tables');
 
-    const edgeTables = await api.tables(newWorkspace, 'edge');
+    const edgeTables = await api.tables(newWorkspace, {
+      type: 'edge',
+    });
     t.deepEqual(edgeTables, ['membership'], 'setting `type` to "edge" reports edge tables');
   } catch(e) {
     t.fail(failMessage('api.tables()', e));
@@ -129,14 +153,20 @@ test('multinet test', async (t) => {
   }
 
   try {
-    let result = await api.createGraph(newWorkspace, 'boston', ['clubs', 'members'], 'membership');
+    let result = await api.createGraph(newWorkspace, 'boston', {
+      nodeTables: ['clubs', 'members'],
+      edgeTable: 'membership',
+    });
     t.equal(result, 'boston', 'boston graph created successfully');
   } catch(e) {
     t.fail(failMessage(`api.createGraph("${newWorkspace}", "boston", ["clubs", "members"], "membership")`, e));
   }
 
   try {
-    result = await api.createGraph(newWorkspace, 'boston', ['clubs', 'members'], 'membership');
+    result = await api.createGraph(newWorkspace, 'boston', {
+      nodeTables: ['clubs', 'members'],
+      edgeTable: 'membership',
+    });
     t.fail('creating an existing graph results should not be successful');
   } catch(e) {
     t.ok(e.status === 409 && e.statusText === 'Graph Already Exists', 'creating an existing graph results in 409 error');
@@ -162,13 +192,22 @@ test('multinet test', async (t) => {
     t.equal(nodes.count, 261, 'graph has correct number of reported nodes');
     t.equal(nodes.nodes.length, 30, 'asking for graph nodes yields 30 items');
 
-    nodes = await api.nodes(newWorkspace, 'boston', 0, 50);
+    nodes = await api.nodes(newWorkspace, 'boston', {
+      offset: 0,
+      limit: 50,
+    });
     t.equal(nodes.nodes.length, 50, 'asking for graph nodes yields 50 items');
 
-    nodes = await api.nodes(newWorkspace, 'boston', 0, 261);
+    nodes = await api.nodes(newWorkspace, 'boston', {
+      offset: 0,
+      limit: 261,
+    });
     t.equal(nodes.nodes.length, 261, 'asking for all graph nodes yields 261 items');
 
-    nodes = await api.nodes(newWorkspace, 'boston', 0, 300);
+    nodes = await api.nodes(newWorkspace, 'boston', {
+      offset: 0,
+      limit: 300,
+    });
     t.equal(nodes.nodes.length, 261, 'asking for more than all graph nodes yields 261 items');
   } catch(e) {
     t.fail(failMessage(`api.nodes("${newWorkspace}", "boston", ...)`, e));
@@ -182,15 +221,21 @@ test('multinet test', async (t) => {
   }
 
   try {
-    let edges = await api.edges(newWorkspace, 'boston', 'clubs/0', 'all');
+    let edges = await api.edges(newWorkspace, 'boston', 'clubs/0', {
+      direction: 'all',
+    });
     t.equal(edges.count, 53, 'correct number of total edges reported');
     t.equal(edges.edges.length, 30, 'correct number of edges sent back');
 
-    edges = await api.edges(newWorkspace, 'boston', 'clubs/0', 'outgoing');
+    edges = await api.edges(newWorkspace, 'boston', 'clubs/0', {
+      direction: 'outgoing',
+    });
     t.equal(edges.count, 0, 'correct number of total outgoing edges reported');
     t.equal(edges.edges.length, 0, 'correct number of outgoing edges sent back');
 
-    edges = await api.edges(newWorkspace, 'boston', 'clubs/0', 'incoming');
+    edges = await api.edges(newWorkspace, 'boston', 'clubs/0', {
+      type: 'incoming',
+    });
     t.equal(edges.count, 53, 'correct number of total incoming edges reported');
     t.equal(edges.edges.length, 30, 'correct number of incoming edges sent back');
 

--- a/scripts/server/start.sh
+++ b/scripts/server/start.sh
@@ -11,7 +11,7 @@ PIPENV_DONT_LOAD_ENV=1 FLASK_APP=multinet FLASK_ENV=development FLASK_SERVE_PORT
 echo $! >server.pid
 
 # Start the Arango database in the background with a clean data directory.
-ARANGO_PORT=58529 ARANGO_DATA=$(readlink -f arango) docker-compose up -d
+ARANGO_PORT=58529 ARANGO_DATA=$(readlink -f arango) docker-compose -p testing up -d
 
 # Loop until the server is up.
 started=0

--- a/scripts/server/stop.sh
+++ b/scripts/server/stop.sh
@@ -8,4 +8,4 @@ if [ -e server.pid ]; then
 fi
 
 # Stop the arango server.
-docker stop arangodb
+docker stop testing_arangodb_1


### PR DESCRIPTION
This PR does a bunch of coordinated things.

1. Replaces direct API calls in the client application with equivalent calls into the multinet client library.
2. Refines the multinetjs client library function signatures.
3. Updates the multinetjs test suite to reflect function signature changes.
4. Adds publishing infrastructure to the multinetjs directory (and, to support (1) above, also published [multinet 0.1.0](https://www.npmjs.com/package/multinet) to NPM.

@jtomeck, could you verify that the client application is working as it did before?

@jeffbaumes and @JackWilb, could you look at the library API and see if it makes sense? Please note that I have not folded in all of the suggestions I've gotten from you in meatspace--Jeff, I haven't created separate "all node" and "all edge" functions, and Jack, I haven't written that utility function that will serially retrieve all the nodes of a graph or table. Planning to add those as needed in followup PRs.