### PR TITLE
Autofocus text fields in graph and table dialogs

### DIFF
--- a/client/src/components/GraphDialog.vue
+++ b/client/src/components/GraphDialog.vue
@@ -28,6 +28,7 @@
           <v-layout wrap>
             <v-flex>
               <v-text-field
+                autofocus
                 filled
                 label="Graph name"
                 v-model="newGraph"

--- a/client/src/components/TableDialog.vue
+++ b/client/src/components/TableDialog.vue
@@ -27,6 +27,7 @@
         <v-layout wrap>
           <v-flex>
             <v-text-field
+              autofocus
               filled
               v-model="newTable"
               label="Table name"


### PR DESCRIPTION
This is a small but important UX improvement.

It does not seem to be working properly: when opening and closing the dialogs a few times, sometimes the text field autofocuses (generally, it seems to be the first time one is opened), and other times it doesn't.

Since this doesn't break anything, I'm inclined to merge it in and figure out why it's not working as desired later on. However, if @jtomeck takes a look now and gives us some advice, that would be great too.