### PR TITLE
Add UI for deleting workspaces

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -39,7 +39,7 @@
     "sass-loader": "^7.2.0",
     "tap-spec": "^5.0.0",
     "tape": "^4.11.0",
-    "typescript": "^3.4.3",
+    "typescript": "^3.6.3",
     "vue-template-compiler": "^2.6.10",
     "vuetify-loader": "^1.3.0"
   },

--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "axios": "^0.18.1",
     "core-js": "^2.6.5",
     "material-design-icons-iconfont": "^5.0.1",
-    "multinet": "^0.2.0",
+    "multinet": "0.3.0",
     "vue": "^2.6.10",
     "vue-router": "^3.0.2",
     "vuetify": "^2.1.5"

--- a/client/src/components/DeleteWorkspaceDialog.vue
+++ b/client/src/components/DeleteWorkspaceDialog.vue
@@ -111,7 +111,7 @@ export default Vue.extend({
         selection,
       } = this;
 
-      selection.forEach(async ws => {
+      selection.forEach(async (ws) => {
         await api.deleteWorkspace(ws);
       });
 

--- a/client/src/components/DeleteWorkspaceDialog.vue
+++ b/client/src/components/DeleteWorkspaceDialog.vue
@@ -115,6 +115,7 @@ export default Vue.extend({
         await api.deleteWorkspace(ws);
       });
 
+      this.$emit('deleted');
       this.dialog = false;
     },
   },

--- a/client/src/components/DeleteWorkspaceDialog.vue
+++ b/client/src/components/DeleteWorkspaceDialog.vue
@@ -1,0 +1,122 @@
+<template>
+
+  <v-dialog
+    v-model="dialog"
+    width="700"
+    >
+
+    <template v-slot:activator="{ on }">
+      <v-tooltip right>
+        <template v-slot:activator="tooltip">
+          <v-scroll-x-transition>
+            <v-btn
+              icon
+              small
+              text
+              v-if="somethingChecked"
+              v-on="on"
+              >
+              <v-icon color="red accent-3" size="22px">delete_sweep</v-icon>
+            </v-btn>
+          </v-scroll-x-transition>
+        </template>
+        <span>Delete selected</span>
+      </v-tooltip>
+    </template>
+
+    <v-card>
+      <v-card-title
+        class="headline pb-0 pt-3"
+        primary-title
+        >
+        Delete Workspaces
+      </v-card-title>
+
+      <v-card-text class="px-4 pt-4 pb-1">
+        You are about to delete {{ selection.length }} workspace{{plural}}. <strong>Are you sure?</strong>
+      </v-card-text>
+
+      <v-divider />
+
+      <v-card-actions class="px-4 py-3">
+        <v-spacer />
+        <v-btn
+          depressed
+          color="error"
+          @click="execute"
+          :disabled="disabled"
+        >yes</v-btn>
+
+        <v-btn
+          depressed
+          @click="dialog = false"
+          >cancel</v-btn>
+      </v-card-actions>
+
+    </v-card>
+
+  </v-dialog>
+
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+import api from '@/api';
+
+export default Vue.extend({
+  props: {
+    somethingChecked: {
+      type: Boolean,
+      required: true,
+    },
+
+    selection: {
+      required: true,
+    },
+  },
+
+  data() {
+    return {
+      dialog: false,
+      disabled: true,
+      timeout: null as number | null,
+    };
+  },
+
+  computed: {
+    plural() {
+      return this.selection.length > 1 ? 's' : '';
+    },
+  },
+
+  watch: {
+    dialog() {
+      if (this.dialog) {
+        this.timeout = window.setTimeout(() => {
+          this.disabled = false;
+          this.timeout = null;
+        }, 2000);
+      } else {
+        window.clearTimeout(this.timeout);
+        this.disabled = true;
+        this.timeout = null;
+      }
+    },
+  },
+
+  methods: {
+    async execute() {
+      const {
+        selection,
+      } = this;
+
+      selection.forEach(async ws => {
+        await api.deleteWorkspace(ws);
+      });
+
+      this.dialog = false;
+    },
+  },
+});
+</script>

--- a/client/src/components/DeleteWorkspaceDialog.vue
+++ b/client/src/components/DeleteWorkspaceDialog.vue
@@ -60,18 +60,19 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import Vue, { PropType } from 'vue';
 
 import api from '@/api';
 
 export default Vue.extend({
   props: {
     somethingChecked: {
-      type: Boolean,
+      type: Object as PropType<boolean>,
       required: true,
     },
 
     selection: {
+      type: Object as PropType<string[]>,
       required: true,
     },
   },
@@ -80,12 +81,13 @@ export default Vue.extend({
     return {
       dialog: false,
       disabled: true,
-      timeout: null as number | null,
+      timeout: undefined as number | undefined,
     };
   },
 
   computed: {
-    plural() {
+    // This workaround is necessary because of https://github.com/vuejs/vue/issues/10455
+    plural(this: any) {
       return this.selection.length > 1 ? 's' : '';
     },
   },
@@ -95,12 +97,12 @@ export default Vue.extend({
       if (this.dialog) {
         this.timeout = window.setTimeout(() => {
           this.disabled = false;
-          this.timeout = null;
+          this.timeout = undefined;
         }, 2000);
       } else {
         window.clearTimeout(this.timeout);
         this.disabled = true;
-        this.timeout = null;
+        this.timeout = undefined;
       }
     },
   },

--- a/client/src/components/DeleteWorkspaceDialog.vue
+++ b/client/src/components/DeleteWorkspaceDialog.vue
@@ -67,12 +67,12 @@ import api from '@/api';
 export default Vue.extend({
   props: {
     somethingChecked: {
-      type: Object as PropType<boolean>,
+      type: Boolean as PropType<boolean>,
       required: true,
     },
 
     selection: {
-      type: Object as PropType<string[]>,
+      type: Array as PropType<string[]>,
       required: true,
     },
   },

--- a/client/src/components/ItemPanel.vue
+++ b/client/src/components/ItemPanel.vue
@@ -55,18 +55,16 @@
           :to="`/workspaces/${workspace}/${routeType}/${item}`"
         >
           <v-list-item-action @click.prevent>
-            <v-fade-transition hide-on-leave>
-              <v-icon
-                color="blue lighten-1"
-                v-if="!hover && !checkbox[item]"
-              >{{icon}}</v-icon>
+            <v-icon
+              color="blue lighten-1"
+              v-if="!hover && !checkbox[item]"
+            >{{icon}}</v-icon>
 
-              <v-checkbox
-                class="ws-detail-checkbox"
-                v-else
-                v-model="checkbox[item]"
-              ></v-checkbox>
-            </v-fade-transition>
+            <v-checkbox
+              class="ws-detail-checkbox"
+              v-else
+              v-model="checkbox[item]"
+            ></v-checkbox>
           </v-list-item-action>
 
           <v-list-item-content>

--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -100,10 +100,10 @@ export default Vue.extend({
 
     selection(): string[] {
       const {
-        checkbox
+        checkbox,
       } = this;
 
-      return Object.keys(checkbox).filter(d => !!checkbox[d]);
+      return Object.keys(checkbox).filter((d) => !!checkbox[d]);
     },
   },
 

--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -30,22 +30,11 @@
         Your Workspaces
         <v-spacer />
 
-          <v-tooltip right>
-            <template v-slot:activator="{ on }">
-              <v-scroll-x-transition>
-                <v-btn
-                  icon
-                  small
-                  text
-                  v-if="somethingChecked"
-                  v-on="on"
-                >
-                  <v-icon color="red accent-3" size="22px">delete_sweep</v-icon>
-                </v-btn>
-              </v-scroll-x-transition>
-            </template>
-            <span>Delete selected</span>
-          </v-tooltip>
+          <delete-workspace-dialog
+            :somethingChecked="somethingChecked"
+            :selection="selection"
+            />
+
       </v-subheader>
 
       <v-divider></v-divider>
@@ -86,6 +75,7 @@ import Vue from 'vue';
 
 import api from '@/api';
 import WorkspaceDialog from '@/components/WorkspaceDialog.vue';
+import DeleteWorkspaceDialog from '@/components/DeleteWorkspaceDialog.vue';
 
 export default Vue.extend({
   data() {
@@ -96,12 +86,21 @@ export default Vue.extend({
     };
   },
   components: {
+    DeleteWorkspaceDialog,
     WorkspaceDialog,
   },
   computed: {
     somethingChecked(): boolean {
       return Object.values(this.checkbox)
         .some((d) => !!d);
+    },
+
+    selection(): string[] {
+      const {
+        checkbox
+      } = this;
+
+      return Object.keys(checkbox).filter(d => !!checkbox[d]);
     },
   },
   methods: {

--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -60,18 +60,16 @@
           :to="`/workspaces/${space}/`"
         >
           <v-list-item-action @click.prevent>
-            <v-fade-transition hide-on-leave>
-              <v-icon
-                color="primary"
-                v-if="!hover && !checkbox[space]"
-              >library_books</v-icon>
+            <v-icon
+              color="primary"
+              v-if="!hover && !checkbox[space]"
+            >library_books</v-icon>
 
-              <v-checkbox
-                class="ws-checkbox"
-                v-else
-                v-model="checkbox[space]"
-              ></v-checkbox>
-            </v-fade-transition>
+            <v-checkbox
+              class="ws-checkbox"
+              v-else
+              v-model="checkbox[space]"
+            ></v-checkbox>
           </v-list-item-action>
 
           <v-list-item-content>

--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -78,12 +78,16 @@ import api from '@/api';
 import WorkspaceDialog from '@/components/WorkspaceDialog.vue';
 import DeleteWorkspaceDialog from '@/components/DeleteWorkspaceDialog.vue';
 
+interface CheckboxTable {
+  [index: string]: boolean;
+}
+
 export default Vue.extend({
   data() {
     return {
       newWorkspace: '',
       workspaces: [] as string[],
-      checkbox: {},
+      checkbox: {} as CheckboxTable,
     };
   },
 
@@ -121,7 +125,7 @@ export default Vue.extend({
       this.workspaces = workspaces.sort();
     },
 
-    delayedRefresh(ms) {
+    delayedRefresh(ms: number) {
       this.checkbox = {};
       this.unroute();
       window.setTimeout(() => this.refresh(), ms);

--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -33,6 +33,7 @@
           <delete-workspace-dialog
             :somethingChecked="somethingChecked"
             :selection="selection"
+            @deleted="delayedRefresh(1000)"
             />
 
       </v-subheader>
@@ -85,10 +86,12 @@ export default Vue.extend({
       checkbox: {},
     };
   },
+
   components: {
     DeleteWorkspaceDialog,
     WorkspaceDialog,
   },
+
   computed: {
     somethingChecked(): boolean {
       return Object.values(this.checkbox)
@@ -103,17 +106,34 @@ export default Vue.extend({
       return Object.keys(checkbox).filter(d => !!checkbox[d]);
     },
   },
+
   methods: {
     route(workspace: string) {
       this.$router.push(`/workspaces/${workspace}`);
     },
+
+    unroute() {
+      this.$router.replace('/');
+    },
+
     addWorkspace(workspace: string) {
       const workspaces = this.workspaces.concat([workspace]);
       this.workspaces = workspaces.sort();
     },
+
+    delayedRefresh(ms) {
+      this.checkbox = {};
+      this.unroute();
+      window.setTimeout(() => this.refresh(), ms);
+    },
+
+    async refresh() {
+      this.workspaces = await api.workspaces();
+    },
   },
+
   async created() {
-    this.workspaces = await api.workspaces();
+    this.refresh();
   },
 });
 </script>

--- a/client/src/views/WorkspaceDetail.vue
+++ b/client/src/views/WorkspaceDetail.vue
@@ -7,17 +7,15 @@
             class="ws-detail-title"
             slot-scope="{ hover }"
           >
-            <v-fade-transition hide-on-leave>
-              <v-icon
-                class="ml-4 mr-5"
-                color="grey lighten-1"
-                v-if="!hover && !editing"
-              >library_books</v-icon>
-            </v-fade-transition>
+            <v-icon
+              class="ml-4 mr-5"
+              color="grey lighten-1"
+              v-if="!hover && !editing"
+            >library_books</v-icon>
 
             <v-tooltip left v-if="!editing">
               <template v-slot:activator="{ on }">
-                <v-fade-transition hide-on-leave>
+                <div>
                   <v-btn
                     class="ml-1 mr-2"
                     icon
@@ -30,25 +28,21 @@
                       size="20px"
                     >edit</v-icon>
                   </v-btn>
-                </v-fade-transition>
+                </div>
               </template>
               <span>Rename workspace</span>
             </v-tooltip>
 
-            <v-fade-transition
-              hide-on-leave
+            <v-btn
               v-if="editing"
+              icon
+              @click="editing = !editing"
             >
-              <v-btn
-                icon
-                @click="editing = !editing"
-              >
-                <v-icon
-                  color="grey darken-3"
-                  size="20px"
-                >close</v-icon>
-              </v-btn>
-            </v-fade-transition>
+              <v-icon
+                color="grey darken-3"
+                size="20px"
+              >close</v-icon>
+            </v-btn>
 
             <span v-if="!editing">{{workspace}}</span>
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8327,10 +8327,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.4.3:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
-  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
+typescript@^3.6.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 uglify-js@3.4.x:
   version "3.4.10"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5517,10 +5517,10 @@ multimatch@^2.1.0:
     arrify "^1.0.0"
     minimatch "^3.0.0"
 
-multinet@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.2.0.tgz#47d2edfab40c574974851ea360e77808391b45ae"
-  integrity sha512-OM1JYAJ//6I6uvHk4fZXF84pRUe0VO738JtBT0ge3+leDgoSIalSAHQHgoPQGsGu5ePJFPHMfQ+I3s5BxLDOxA==
+multinet@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.3.0.tgz#d89ba1269d1d5e29610f359bf8043d04991a93f3"
+  integrity sha512-wZvhhz2rtE0KMWUJRxuXsJXlwnqbS5XSCEJBVBYJICK+G0s/39g2Jd+NVDpJeET9b9s5lu8coZMb2/0LmDrcMQ==
   dependencies:
     axios "^0.19.0"
 

--- a/multinetjs/package.json
+++ b/multinetjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multinet",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Multinet client library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/multinetjs/src/client.ts
+++ b/multinetjs/src/client.ts
@@ -32,4 +32,16 @@ export class Client {
         });
     });
   }
+
+  public delete(path: string, params: {} = {}): Promise<any> {
+    return new Promise((resolve, reject) => {
+      this.axios.delete(path, params)
+        .then((resp) => {
+          resolve(resp.data);
+        })
+        .catch((resp) => {
+          reject(resp.response);
+        });
+    });
+  }
 }

--- a/multinetjs/src/index.ts
+++ b/multinetjs/src/index.ts
@@ -118,6 +118,10 @@ class MultinetAPI {
     return this.client.post(`/workspaces/${workspace}`);
   }
 
+  public deleteWorkspace(workspace: string): Promise<string> {
+    return this.client.delete(`/workspaces/${workspace}`);
+  }
+
   public async uploadTable(workspace: string, table: string, options: UploadTableOptionsSpec): Promise<Array<{}>> {
     let text;
     if (typeof options.data === 'string') {


### PR DESCRIPTION
Depends on multinet-app/multinet-server#212 and multinet-app/multinet-server#216 
Closes multinet-app/multinet-server#78 

This PR adds functionality to the "delete workspaces" button.

It adds a confirmation dialog with a built-in delay of 2 seconds before the user can click the "confirm" button.

One issue is that the `GET /workspaces` endpoint doesn't seem to immediately update after the `DELETE /workspaces/<id>` call succeeds. To get around this, I have a one-second delay before the Sidebar component refreshes the workspaces list. One second works but is not guaranteed formally. A better solution might be to manually update the Sidebar component's workspace list (as we do when creating a new workspace), in which case the delay won't matter.

Another important task here is to review just the changes to the `multinet` directory, so that I can cut a release of that and make use of it in the client.

I'd like a bunch of reviews on this for various aspects:
- @JackWilb: please let me know if this is the right interaction for what we need in the Multinet project
- @jtomeck: please confirm that my use of Vuetify is good and correct (and that the style is reasonable)
- @subdavis: I can't formally request a review from you until you accept the invitation to the project, but I'd like to know if my Vue/TypeScript usage here is good

Thanks everyone!

TODO:
- [x] Release multinetjs 0.3.0 (which includes `deleteWorkspace()` function)
- [x] Update client to use multinetjs 0.3.0