### PR TITLE
Fix tooltip positioning bug

### DIFF
--- a/client/src/components/DeleteWorkspaceDialog.vue
+++ b/client/src/components/DeleteWorkspaceDialog.vue
@@ -5,16 +5,17 @@
     width="700"
     >
 
-    <template v-slot:activator="{ on }">
+    <template v-slot:activator="{ on: dialog }">
       <v-tooltip right>
-        <template v-slot:activator="tooltip">
+        <template v-slot:activator="{ on: tooltip }">
           <v-scroll-x-transition>
             <v-btn
               icon
               small
               text
               v-if="somethingChecked"
-              v-on="on"
+              @click="dialog.click"
+              v-on="tooltip"
               >
               <v-icon color="red accent-3" size="22px">delete_sweep</v-icon>
             </v-btn>

--- a/client/src/components/DeleteWorkspaceDialog.vue
+++ b/client/src/components/DeleteWorkspaceDialog.vue
@@ -3,6 +3,7 @@
   <v-dialog
     v-model="dialog"
     width="700"
+    v-if="somethingChecked"
     >
 
     <template v-slot:activator="{ on: dialog }">
@@ -13,7 +14,6 @@
               icon
               small
               text
-              v-if="somethingChecked"
               @click="dialog.click"
               v-on="tooltip"
               >

--- a/client/src/components/ItemPanel.vue
+++ b/client/src/components/ItemPanel.vue
@@ -9,14 +9,13 @@
 
       <v-spacer />
 
-      <v-tooltip top>
+      <v-tooltip top v-if="anySelected">
         <template v-slot:activator="{ on }">
           <v-scroll-x-transition>
             <v-btn
               icon
               small
               text
-              v-if="anySelected"
               v-on="on"
             >
               <v-icon color="red accent-2" size="22px">delete_sweep</v-icon>


### PR DESCRIPTION
According to https://github.com/vuetifyjs/vuetify/issues/10037 we can fix the tooltip positioning issue by hoisting the v-if upward. Unfortunately, tooltips just don't work well with transitions, though they are working on fixing that in a later release. Consequently, I'm leaving the transition components in the code, but they don't actually work.

I figured it was better to have correctly positioned tooltips and put the transition animations on hold, if that's the cost of doing so.