### PR TITLE
Add UI for deleting graphs and tables

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "axios": "^0.18.1",
     "core-js": "^2.6.5",
     "material-design-icons-iconfont": "^5.0.1",
-    "multinet": "0.3.0",
+    "multinet": "0.4.0",
     "vue": "^2.6.10",
     "vue-router": "^3.0.2",
     "vuetify": "^2.1.5"

--- a/client/src/components/DeleteGraphDialog.vue
+++ b/client/src/components/DeleteGraphDialog.vue
@@ -1,0 +1,126 @@
+<template>
+
+  <v-dialog
+    v-model="dialog"
+    width="700"
+    >
+
+    <template v-slot:activator="{ on }">
+      <v-tooltip right>
+        <template v-slot:activator="tooltip">
+          <v-scroll-x-transition>
+            <v-btn
+              icon
+              small
+              text
+              v-if="nonZeroSelection"
+              v-on="on"
+              >
+              <v-icon color="red accent-3" size="22px">delete_sweep</v-icon>
+            </v-btn>
+          </v-scroll-x-transition>
+        </template>
+        <span>Delete selected</span>
+      </v-tooltip>
+    </template>
+
+    <v-card>
+      <v-card-title
+        class="headline pb-0 pt-3 px-5"
+        primary-title
+        >
+        Delete Workspaces
+      </v-card-title>
+
+      <v-card-text class="px-5 py-4">
+        You are about to delete {{ selection.length }} graph{{plural}}. <strong>Are you sure?</strong>
+      </v-card-text>
+
+      <v-divider />
+
+      <v-card-actions class="px-4 py-3">
+        <v-spacer />
+        <v-btn
+          depressed
+          color="error"
+          @click="execute"
+          :disabled="disabled"
+        >yes</v-btn>
+
+        <v-btn
+          depressed
+          @click="dialog = false"
+          >cancel</v-btn>
+      </v-card-actions>
+
+    </v-card>
+
+  </v-dialog>
+
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+
+import api from '@/api';
+
+export default Vue.extend({
+  props: {
+    selection: {
+      type: Array as PropType<string[]>,
+      required: true,
+    },
+  },
+
+  data() {
+    return {
+      dialog: false,
+      disabled: true,
+      timeout: undefined as number | undefined,
+    };
+  },
+
+  computed: {
+    // This workaround is necessary because of https://github.com/vuejs/vue/issues/10455
+    plural(this: any) {
+      return this.selection.length > 1 ? 's' : '';
+    },
+
+    nonZeroSelection(): boolean {
+      return this.selection.length > 0;
+    },
+  },
+
+  watch: {
+    dialog() {
+      if (this.dialog) {
+        this.timeout = window.setTimeout(() => {
+          this.disabled = false;
+          this.timeout = undefined;
+        }, 2000);
+      } else {
+        window.clearTimeout(this.timeout);
+        this.disabled = true;
+        this.timeout = undefined;
+      }
+    },
+  },
+
+  methods: {
+    async execute() {
+      const {
+        selection,
+      } = this;
+
+      // selection.forEach(async (ws) => {
+        // await api.deleteWorkspace(ws);
+      // });
+
+      console.log(selection);
+
+      this.$emit('deleted');
+      this.dialog = false;
+    },
+  },
+});
+</script>

--- a/client/src/components/DeleteGraphDialog.vue
+++ b/client/src/components/DeleteGraphDialog.vue
@@ -29,7 +29,7 @@
         class="headline pb-0 pt-3 px-5"
         primary-title
         >
-        Delete Workspaces
+        Delete Graphs
       </v-card-title>
 
       <v-card-text class="px-5 py-4">
@@ -68,6 +68,11 @@ export default Vue.extend({
   props: {
     selection: {
       type: Array as PropType<string[]>,
+      required: true,
+    },
+
+    workspace: {
+      type: String as PropType<string>,
       required: true,
     },
   },
@@ -110,13 +115,12 @@ export default Vue.extend({
     async execute() {
       const {
         selection,
+        workspace,
       } = this;
 
-      // selection.forEach(async (ws) => {
-        // await api.deleteWorkspace(ws);
-      // });
-
-      console.log(selection);
+      selection.forEach(async (graph) => {
+        await api.deleteGraph(workspace, graph);
+      });
 
       this.$emit('deleted');
       this.dialog = false;

--- a/client/src/components/DeleteGraphDialog.vue
+++ b/client/src/components/DeleteGraphDialog.vue
@@ -3,18 +3,18 @@
   <v-dialog
     v-model="dialog"
     width="700"
-    >
-
-    <template v-slot:activator="{ on }">
-      <v-tooltip right>
-        <template v-slot:activator="tooltip">
+    v-if="nonZeroSelection"
+  >
+    <template v-slot:activator="{ on: dialog }">
+      <v-tooltip left>
+        <template v-slot:activator="{ on: tooltip }">
           <v-scroll-x-transition>
             <v-btn
               icon
               small
               text
-              v-if="nonZeroSelection"
-              v-on="on"
+              @click="dialog.click"
+              v-on="tooltip"
               >
               <v-icon color="red accent-3" size="22px">delete_sweep</v-icon>
             </v-btn>

--- a/client/src/components/DeleteTableDialog.vue
+++ b/client/src/components/DeleteTableDialog.vue
@@ -65,7 +65,7 @@
         The following graphs are using these tables:
         <ul>
           <li v-for="graph in using">
-            {{ graph }}
+            {{ graph.graph }} ({{ graph.tables.join(', ') }})
           </li>
         </ul>
       </v-card-text>
@@ -113,7 +113,7 @@ export default Vue.extend({
       dialog: false,
       disabled: true,
       timeout: undefined as number | undefined,
-      using: [] as string[],
+      using: [] as Array<{graph: string, tables: string[]}>,
     };
   },
 
@@ -135,6 +135,7 @@ export default Vue.extend({
   watch: {
     async dialog() {
       if (this.dialog) {
+        this.using = [];
         const using = await this.findDependentGraphs();
         if (using.length > 0) {
           this.using = using;
@@ -175,13 +176,22 @@ export default Vue.extend({
 
       const graphNames = await api.graphs(workspace);
 
-      console.log(selection);
-
-      const using = [] as string[];
+      const using = [] as Array<{graph: string, tables: string[]}>;
       for (const graph of graphNames) {
         const data = await api.graph(workspace, graph);
-        if (selection.some((table) => data.edgeTable === table || data.nodeTables.indexOf(table) > -1)) {
-          using.push(graph);
+
+        const tables = [];
+        for (const table of selection) {
+          if (table === data.edgeTable || data.nodeTables.indexOf(table) > -1) {
+            tables.push(table);
+          }
+        }
+
+        if (tables.length > 0) {
+          using.push({
+            graph,
+            tables,
+          });
         }
       }
 

--- a/client/src/components/DeleteTableDialog.vue
+++ b/client/src/components/DeleteTableDialog.vue
@@ -1,0 +1,130 @@
+<template>
+
+  <v-dialog
+    v-model="dialog"
+    width="700"
+    >
+
+    <template v-slot:activator="{ on }">
+      <v-tooltip right>
+        <template v-slot:activator="tooltip">
+          <v-scroll-x-transition>
+            <v-btn
+              icon
+              small
+              text
+              v-if="nonZeroSelection"
+              v-on="on"
+              >
+              <v-icon color="red accent-3" size="22px">delete_sweep</v-icon>
+            </v-btn>
+          </v-scroll-x-transition>
+        </template>
+        <span>Delete selected</span>
+      </v-tooltip>
+    </template>
+
+    <v-card>
+      <v-card-title
+        class="headline pb-0 pt-3 px-5"
+        primary-title
+        >
+        Delete Tables
+      </v-card-title>
+
+      <v-card-text class="px-5 py-4">
+        You are about to delete {{ selection.length }} table{{plural}}. <strong>Are you sure?</strong>
+      </v-card-text>
+
+      <v-divider />
+
+      <v-card-actions class="px-4 py-3">
+        <v-spacer />
+        <v-btn
+          depressed
+          color="error"
+          @click="execute"
+          :disabled="disabled"
+        >yes</v-btn>
+
+        <v-btn
+          depressed
+          @click="dialog = false"
+          >cancel</v-btn>
+      </v-card-actions>
+
+    </v-card>
+
+  </v-dialog>
+
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+
+import api from '@/api';
+
+export default Vue.extend({
+  props: {
+    selection: {
+      type: Array as PropType<string[]>,
+      required: true,
+    },
+
+    workspace: {
+      type: String as PropType<string>,
+      required: true,
+    },
+  },
+
+  data() {
+    return {
+      dialog: false,
+      disabled: true,
+      timeout: undefined as number | undefined,
+    };
+  },
+
+  computed: {
+    // This workaround is necessary because of https://github.com/vuejs/vue/issues/10455
+    plural(this: any) {
+      return this.selection.length > 1 ? 's' : '';
+    },
+
+    nonZeroSelection(): boolean {
+      return this.selection.length > 0;
+    },
+  },
+
+  watch: {
+    dialog() {
+      if (this.dialog) {
+        this.timeout = window.setTimeout(() => {
+          this.disabled = false;
+          this.timeout = undefined;
+        }, 2000);
+      } else {
+        window.clearTimeout(this.timeout);
+        this.disabled = true;
+        this.timeout = undefined;
+      }
+    },
+  },
+
+  methods: {
+    async execute() {
+      const {
+        selection,
+        workspace,
+      } = this;
+
+      selection.forEach(async (table) => {
+        await api.deleteTable(workspace, table);
+      });
+
+      this.$emit('deleted');
+      this.dialog = false;
+    },
+  },
+});
+</script>

--- a/client/src/components/DeleteTableDialog.vue
+++ b/client/src/components/DeleteTableDialog.vue
@@ -3,18 +3,18 @@
   <v-dialog
     v-model="dialog"
     width="700"
-    >
-
-    <template v-slot:activator="{ on }">
-      <v-tooltip right>
-        <template v-slot:activator="tooltip">
+    v-if="nonZeroSelection"
+  >
+    <template v-slot:activator="{ on: dialog }">
+      <v-tooltip left>
+        <template v-slot:activator="{ on: tooltip }">
           <v-scroll-x-transition>
             <v-btn
               icon
               small
               text
-              v-if="nonZeroSelection"
-              v-on="on"
+              @click="dialog.click"
+              v-on="tooltip"
               >
               <v-icon color="red accent-3" size="22px">delete_sweep</v-icon>
             </v-btn>

--- a/client/src/components/DeleteTableDialog.vue
+++ b/client/src/components/DeleteTableDialog.vue
@@ -24,7 +24,7 @@
       </v-tooltip>
     </template>
 
-    <v-card>
+    <v-card v-if="!dependentGraphs">
       <v-card-title
         class="headline pb-0 pt-3 px-5"
         primary-title
@@ -52,7 +52,38 @@
           @click="dialog = false"
           >cancel</v-btn>
       </v-card-actions>
+    </v-card>
+    <v-card v-else>
+      <v-card-title
+        class="headline pb-0 pt-3 px-5"
+        primary-title
+        >
+        Delete Tables
+      </v-card-title>
 
+      <v-card-text class="px-5 py-4">
+        The following graphs are using these tables:
+        <ul>
+          <li v-for="graph in using">
+            {{ graph }}
+          </li>
+        </ul>
+      </v-card-text>
+
+      <v-card-text class="px-5 py-4">
+        You must delete these graphs before you can delete the tables.
+      </v-card-text>
+
+      <v-divider />
+
+      <v-card-actions class="px-4 py-3">
+        <v-spacer />
+
+        <v-btn
+          depressed
+          @click="dialog = false"
+          >ok</v-btn>
+      </v-card-actions>
     </v-card>
 
   </v-dialog>
@@ -82,6 +113,7 @@ export default Vue.extend({
       dialog: false,
       disabled: true,
       timeout: undefined as number | undefined,
+      using: [] as string[],
     };
   },
 
@@ -94,15 +126,24 @@ export default Vue.extend({
     nonZeroSelection(): boolean {
       return this.selection.length > 0;
     },
+
+    dependentGraphs(): boolean {
+      return this.using.length > 0;
+    },
   },
 
   watch: {
-    dialog() {
+    async dialog() {
       if (this.dialog) {
-        this.timeout = window.setTimeout(() => {
-          this.disabled = false;
-          this.timeout = undefined;
-        }, 2000);
+        const using = await this.findDependentGraphs();
+        if (using.length > 0) {
+          this.using = using;
+        } else {
+          this.timeout = window.setTimeout(() => {
+            this.disabled = false;
+            this.timeout = undefined;
+          }, 2000);
+        }
       } else {
         window.clearTimeout(this.timeout);
         this.disabled = true;
@@ -124,6 +165,27 @@ export default Vue.extend({
 
       this.$emit('deleted');
       this.dialog = false;
+    },
+
+    async findDependentGraphs() {
+      const {
+        selection,
+        workspace,
+      } = this;
+
+      const graphNames = await api.graphs(workspace);
+
+      console.log(selection);
+
+      const using = [] as string[];
+      for (const graph of graphNames) {
+        const data = await api.graph(workspace, graph);
+        if (selection.some((table) => data.edgeTable === table || data.nodeTables.indexOf(table) > -1)) {
+          using.push(graph);
+        }
+      }
+
+      return using;
     },
   },
 });

--- a/client/src/components/DeleteWorkspaceDialog.vue
+++ b/client/src/components/DeleteWorkspaceDialog.vue
@@ -7,7 +7,7 @@
     >
 
     <template v-slot:activator="{ on: dialog }">
-      <v-tooltip right>
+      <v-tooltip left>
         <template v-slot:activator="{ on: tooltip }">
           <v-scroll-x-transition>
             <v-btn

--- a/client/src/components/ItemPanel.vue
+++ b/client/src/components/ItemPanel.vue
@@ -9,7 +9,11 @@
 
       <v-spacer />
 
-      <slot name="deleter" :selection="selection"></slot>
+      <slot name="deleter"
+            :selection="selection"
+            :workspace="workspace"
+            >
+      </slot>
 
       <slot></slot>
 
@@ -106,6 +110,14 @@ export default Vue.extend({
 
     anySelected(): boolean {
       return this.selection.length > 0;
+    },
+  },
+
+  methods: {
+    clearCheckboxes() {
+      Object.keys(this.checkbox).forEach((key) => {
+        this.checkbox[key] = false;
+      });
     },
   },
 });

--- a/client/src/components/ItemPanel.vue
+++ b/client/src/components/ItemPanel.vue
@@ -9,22 +9,7 @@
 
       <v-spacer />
 
-      <v-tooltip top>
-        <template v-slot:activator="{ on }">
-          <v-scroll-x-transition>
-            <v-btn
-              icon
-              small
-              text
-              v-if="anySelected"
-              v-on="on"
-            >
-              <v-icon color="red accent-2" size="22px">delete_sweep</v-icon>
-            </v-btn>
-          </v-scroll-x-transition>
-        </template>
-        <span>Delete selected</span>
-      </v-tooltip>
+      <slot name="deleter" :selection="selection"></slot>
 
       <slot></slot>
 
@@ -105,14 +90,22 @@ export default Vue.extend({
     },
   },
   data() {
+    interface CheckboxTable {
+      [index: string]: boolean;
+    }
+
     return {
-      checkbox: {},
+      checkbox: {} as CheckboxTable,
     };
   },
   computed: {
+    selection(): string[] {
+      return Object.keys(this.checkbox)
+        .filter((d) => !!this.checkbox[d]);
+    },
+
     anySelected(): boolean {
-      return Object.values(this.checkbox)
-        .some((d) => !!d);
+      return this.selection.length > 0;
     },
   },
 });

--- a/client/src/views/WorkspaceDetail.vue
+++ b/client/src/views/WorkspaceDetail.vue
@@ -81,6 +81,7 @@
             text
           >
             <item-panel
+              ref="tablePanel"
               title="Tables"
               :items="tables"
               :workspace="workspace"
@@ -106,6 +107,7 @@
             text
           >
             <item-panel
+              ref="graphPanel"
               title="Graphs"
               :items="graphs"
               :workspace="workspace"
@@ -122,6 +124,8 @@
                 <template v-slot:deleter="deleter">
                   <delete-graph-dialog
                     :selection="deleter.selection"
+                    :workspace="deleter.workspace"
+                    @deleted="update"
                     />
                 </template>
             </item-panel>
@@ -184,6 +188,10 @@ export default Vue.extend({
 
       // Get list of graphs.
       this.graphs = await api.graphs(this.workspace);
+
+      // Instruct both ItemPanels to clear their checkbox state.
+      this.$refs.graphPanel.clearCheckboxes();
+      this.$refs.tablePanel.clearCheckboxes();
     },
   },
   created() {

--- a/client/src/views/WorkspaceDetail.vue
+++ b/client/src/views/WorkspaceDetail.vue
@@ -187,7 +187,7 @@ export default Vue.extend({
     },
   },
   methods: {
-    async update() {
+    async update(this: any) {
       // Get lists of node and edge tables.
       const nodeTables = await api.tables(this.workspace, { type: 'node' });
       const edgeTables = await api.tables(this.workspace, { type: 'edge' });

--- a/client/src/views/WorkspaceDetail.vue
+++ b/client/src/views/WorkspaceDetail.vue
@@ -92,6 +92,14 @@
                   :workspace="workspace"
                   @success="update"
                   />
+
+                <template v-slot:deleter="deleter">
+                  <delete-table-dialog
+                    :selection="deleter.selection"
+                    :workspace="deleter.workspace"
+                    @deleted="update"
+                    />
+                </template>
             </item-panel>
 
           </v-card>
@@ -145,6 +153,7 @@ import ItemPanel from '@/components/ItemPanel.vue';
 import GraphDialog from '@/components/GraphDialog.vue';
 import DeleteGraphDialog from '@/components/DeleteGraphDialog.vue';
 import TableDialog from '@/components/TableDialog.vue';
+import DeleteTableDialog from '@/components/DeleteTableDialog.vue';
 
 import { FileTypeTable } from '@/types';
 
@@ -155,6 +164,7 @@ export default Vue.extend({
     GraphDialog,
     DeleteGraphDialog,
     TableDialog,
+    DeleteTableDialog,
   },
   props: ['workspace', 'title'],
   data() {

--- a/client/src/views/WorkspaceDetail.vue
+++ b/client/src/views/WorkspaceDetail.vue
@@ -118,6 +118,12 @@
                   :workspace="workspace"
                   @success="update"
                   />
+
+                <template v-slot:deleter="deleter">
+                  <delete-graph-dialog
+                    :selection="deleter.selection"
+                    />
+                </template>
             </item-panel>
 
           </v-card>
@@ -133,6 +139,7 @@ import Vue from 'vue';
 import api from '@/api';
 import ItemPanel from '@/components/ItemPanel.vue';
 import GraphDialog from '@/components/GraphDialog.vue';
+import DeleteGraphDialog from '@/components/DeleteGraphDialog.vue';
 import TableDialog from '@/components/TableDialog.vue';
 
 import { FileTypeTable } from '@/types';
@@ -142,6 +149,7 @@ export default Vue.extend({
   components: {
     ItemPanel,
     GraphDialog,
+    DeleteGraphDialog,
     TableDialog,
   },
   props: ['workspace', 'title'],

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5517,10 +5517,10 @@ multimatch@^2.1.0:
     arrify "^1.0.0"
     minimatch "^3.0.0"
 
-multinet@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.3.0.tgz#d89ba1269d1d5e29610f359bf8043d04991a93f3"
-  integrity sha512-wZvhhz2rtE0KMWUJRxuXsJXlwnqbS5XSCEJBVBYJICK+G0s/39g2Jd+NVDpJeET9b9s5lu8coZMb2/0LmDrcMQ==
+multinet@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.4.0.tgz#7ab483334f97e25b855ba6aea36e025ef98f11b8"
+  integrity sha512-lxK6pAA0rcaJUPIBwPSy4JU8PABpTQuRnEG+6k+vGmDTHwwvYmzq4WEGfGZIafXefzmZnuqqfq0PV3AQBkRKmw==
   dependencies:
     axios "^0.19.0"
 

--- a/multinet/api.py
+++ b/multinet/api.py
@@ -205,3 +205,11 @@ def create_graph(
 
     db.create_graph(workspace, graph, node_tables, edge_table)
     return graph
+
+
+@bp.route("/workspaces/<workspace>/graphs/<graph>", methods=["DELETE"])
+@swag_from("swagger/delete_graph.yaml")
+def delete_graph(workspace: str, graph: str) -> Any:
+    """Delete a graph."""
+    db.delete_graph(workspace, graph)
+    return graph

--- a/multinet/api.py
+++ b/multinet/api.py
@@ -213,3 +213,11 @@ def delete_graph(workspace: str, graph: str) -> Any:
     """Delete a graph."""
     db.delete_graph(workspace, graph)
     return graph
+
+
+@bp.route("/workspaces/<workspace>/tables/<table>", methods=["DELETE"])
+@swag_from("swagger/delete_table.yaml")
+def delete_table(workspace: str, table: str) -> Any:
+    """Delete a table."""
+    db.delete_table(workspace, table)
+    return table

--- a/multinet/db.py
+++ b/multinet/db.py
@@ -283,6 +283,16 @@ def table_fields(workspace: str, table: str, arango: ArangoClient) -> List[str]:
 
 
 @with_client
+def delete_table(workspace: str, table: str, arango: ArangoClient) -> str:
+    """Delete a table."""
+    space = db(workspace, arango=arango)
+    if space.has_collection(table):
+        space.delete_collection(table)
+
+    return table
+
+
+@with_client
 def aql_query(
     workspace: str, query: str, arango: ArangoClient
 ) -> Generator[dict, None, None]:

--- a/multinet/db.py
+++ b/multinet/db.py
@@ -317,6 +317,16 @@ def create_graph(
 
 
 @with_client
+def delete_graph(workspace: str, graph: str, arango: ArangoClient) -> str:
+    """Delete graph `graph` from workspace `workspace`."""
+    space = db(workspace, arango=arango)
+    if space.has_graph(graph):
+        space.delete_graph(graph)
+
+    return graph
+
+
+@with_client
 def graph_node_tables(
     workspace: str, graph: str, arango: ArangoClient
 ) -> List[StandardCollection]:

--- a/multinet/swagger/delete_graph.yaml
+++ b/multinet/swagger/delete_graph.yaml
@@ -1,0 +1,15 @@
+Delete a graph
+---
+parameters:
+  - $ref: "#/parameters/workspace"
+  - $ref: "#/parameters/graph"
+
+responses:
+  200:
+    description: Graph successfully deleted
+    schema:
+      type: string
+      example: graph5
+
+tags:
+  - graph

--- a/multinet/swagger/delete_table.yaml
+++ b/multinet/swagger/delete_table.yaml
@@ -1,0 +1,15 @@
+Delete a table
+---
+parameters:
+  - $ref: "#/parameters/workspace"
+  - $ref: "#/parameters/table"
+
+responses:
+  200:
+    description: Table successfully deleted
+    schema:
+      type: string
+      example: table4
+
+tags:
+  - table

--- a/multinetjs/package.json
+++ b/multinetjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multinet",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Multinet client library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/multinetjs/src/index.ts
+++ b/multinetjs/src/index.ts
@@ -141,6 +141,10 @@ class MultinetAPI {
       edge_table: options.edgeTable,
     });
   }
+
+  public deleteGraph(workspace: string, graph: string): Promise<string> {
+    return this.client.delete(`/workspaces/${workspace}/graphs/${graph}`);
+  }
 }
 
 export function multinetApi(baseURL: string): MultinetAPI {

--- a/multinetjs/src/index.ts
+++ b/multinetjs/src/index.ts
@@ -135,6 +135,10 @@ class MultinetAPI {
     });
   }
 
+  public deleteTable(workspace: string, table: string): Promise<string> {
+    return this.client.delete(`/workspaces/${workspace}/tables/${table}`);
+  }
+
   public createGraph(workspace: string, graph: string, options: CreateGraphOptionsSpec): Promise<string> {
     return this.client.post(`/workspaces/${workspace}/graphs/${graph}`, {
       node_tables: options.nodeTables,


### PR DESCRIPTION
This adds several pieces to support graph and table deletion in the client:
- API pieces for deleting graphs and deleting tables
- client library functions for accessing those new API routes
- dialogs in the client to implement graph deletion and table deletion
  - a safety interlock on table deletion: if an existing graph uses any of the tables slated for deletion, the UI will not allow the deletion to proceed until the affected graphs are deleted first

Because this PR updates the client library, it's necessary to use `yarn link` in order to test locally:
1. Go into the `multinetjs` directory, run `yarn install` and then `yarn build` there.
2. Run `yarn link` and verify that the system has registered multinet as a linkable module.
3. Go into the `client` directory and run `yarn link multinet` to use the linked version of the multinet library.
4. Run `yarn install` and `yarn serve` again if necessary.

These steps will let you use the modified version of multinetjs for testing.

That also means there are TODO items before merging this PR:
- [x] Cut a release of multinetjs
- [x] Update the client code to make use of the new version of multinetjs

I will take care of these TODOs after review is done, and just before I merge.