### PR TITLE
Fixed table header

### DIFF
--- a/client/src/views/TableDetail.vue
+++ b/client/src/views/TableDetail.vue
@@ -66,6 +66,8 @@
       </v-app-bar>
       <div class="wrapper">
         <v-data-table
+          fixed-header
+          height="calc(100vh - 123px)"
           class="table-details"
           :headers="dataTableHeaders"
           :items="dataTableRows"

--- a/client/src/views/TableDetail.vue
+++ b/client/src/views/TableDetail.vue
@@ -71,7 +71,11 @@
           class="table-details"
           :headers="dataTableHeaders"
           :items="dataTableRows"
-          :items-per-page="15"
+          :items-per-page="20"
+          :footer-props="{
+            itemsPerPageOptions: [5, 10, 15, 20, -1],
+            showFirstLastPage: true,
+          }"
         />
       </div>
     </v-content>

--- a/client/src/views/TableDetail.vue
+++ b/client/src/views/TableDetail.vue
@@ -71,11 +71,7 @@
           class="table-details"
           :headers="dataTableHeaders"
           :items="dataTableRows"
-          :items-per-page="20"
-          :footer-props="{
-            itemsPerPageOptions: [5, 10, 15, 20, -1],
-            showFirstLastPage: true,
-          }"
+          :items-per-page="15"
         />
       </div>
     </v-content>


### PR DESCRIPTION
Fixes #245 

This also tweaks the paging options a bit. Now that the table is full height, if there are less items in the table there is just white space. @waxlamp - Do you think it makes sense to update the "rows per page" options to have a minimum of 15 and go `[15, 20, 25, 30, -1]`?