### PR TITLE
Add an "about" panel that can optionally include a Git SHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
       - run: cd client && yarn lint
       - run: cd client && yarn lint:test
       - run: cd client && yarn test
+      - run: "cd client && git rev-parse HEAD >git-sha"
       - run: cd client && yarn build
 
       # Build and test Multinet client library.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,6 @@ jobs:
       - run: cd client && yarn lint
       - run: cd client && yarn lint:test
       - run: cd client && yarn test
-      - run: "cd client && git rev-parse HEAD >git-sha"
       - run: cd client && yarn build
 
       # Build and test Multinet client library.

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -19,3 +19,6 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw?
+
+# Deployment files
+git-sha

--- a/client/src/components/AboutDialog.vue
+++ b/client/src/components/AboutDialog.vue
@@ -28,6 +28,16 @@
       </v-card-title>
 
       <v-card-text
+        class="px-4 pt-4 pb-1"
+        >
+        Multinet is a system for storing and processing <a
+          href="https://vdl.sci.utah.edu/mvnv/" rel="noopener
+          noreferrer">multivariate networks</a>. Learn more and explore the code
+        at <a href="https://github.com/multinet-app/multinet" rel="noopener
+          noreferrer">GitHub</a>.
+      </v-card-text>
+
+      <v-card-text
         v-if="gitSha"
         class="px-4 pt-4 pb-1"
         >

--- a/client/src/components/AboutDialog.vue
+++ b/client/src/components/AboutDialog.vue
@@ -1,0 +1,65 @@
+<template>
+  <v-dialog
+    class="ws-dialog"
+    v-model="dialog"
+    width="500"
+    >
+    <template v-slot:activator="{ on }">
+      <v-btn
+        class="ws-btn"
+        block
+        color="blue darken-3"
+        dark
+        depressed
+        large
+        v-on="on"
+        >
+        About Multinet
+      </v-btn>
+    </template>
+
+    <v-card>
+
+      <v-card-title
+        class="headline pb-0 pt-3"
+        primary-title
+        >
+        About Multinet
+      </v-card-title>
+
+      <v-card-text class="px-4 pt-4 pb-1">
+        Hello.
+      </v-card-text>
+
+      <v-divider />
+
+      <v-card-actions class="px-4 py-3">
+        <v-spacer />
+
+        <v-btn
+          color="grey darken-3"
+          dark
+          depressed
+          @click="dialog = false"
+          >
+          OK
+        </v-btn>
+      </v-card-actions>
+
+    </v-card>
+
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
+  data() {
+    return {
+      dialog: false,
+    };
+  },
+});
+
+</script>

--- a/client/src/components/AboutDialog.vue
+++ b/client/src/components/AboutDialog.vue
@@ -6,16 +6,12 @@
     >
     <template v-slot:activator="{ on }">
       <v-btn
-        class="ws-btn"
-        block
-        color="blue darken-3"
-        dark
-        depressed
-        large
-        tile
+        class="mt-n1 ml-n1"
+        icon
+        small
         v-on="on"
-        >
-        About Multinet
+      >
+        <v-icon size="18">help</v-icon>
       </v-btn>
     </template>
 

--- a/client/src/components/AboutDialog.vue
+++ b/client/src/components/AboutDialog.vue
@@ -27,8 +27,12 @@
         About Multinet
       </v-card-title>
 
-      <v-card-text class="px-4 pt-4 pb-1">
-        Hello.
+      <v-card-text
+        v-if="gitSha"
+        class="px-4 pt-4 pb-1"
+        >
+        This instance of Multinet was built from Git SHA
+        <a :href="gitShaURL" target="_blank" rel="noopener noreferrer">{{gitSha.slice(0, 6)}}</a>.
       </v-card-text>
 
       <v-divider />
@@ -54,12 +58,29 @@
 <script lang="ts">
 import Vue from 'vue';
 
+declare var GIT_SHA: string;
+
 export default Vue.extend({
   data() {
     return {
       dialog: false,
     };
   },
+
+  computed: {
+    gitSha() {
+      return GIT_SHA;
+    },
+
+    gitShaURL(this: any) {
+      const {
+        gitSha,
+      } = this;
+
+      return `https://github.com/multinet-app/multinet/tree/${gitSha}`;
+    },
+  },
+
 });
 
 </script>

--- a/client/src/components/AboutDialog.vue
+++ b/client/src/components/AboutDialog.vue
@@ -79,7 +79,7 @@ export default Vue.extend({
   },
 
   computed: {
-    gitSha() {
+    gitSha(): string {
       return GIT_SHA;
     },
 

--- a/client/src/components/AboutDialog.vue
+++ b/client/src/components/AboutDialog.vue
@@ -69,7 +69,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
-declare var GIT_SHA: string;
+declare const GIT_SHA: string;
 
 export default Vue.extend({
   data() {

--- a/client/src/components/AboutDialog.vue
+++ b/client/src/components/AboutDialog.vue
@@ -83,7 +83,7 @@ export default Vue.extend({
       return GIT_SHA;
     },
 
-    gitShaURL(this: any) {
+    gitShaURL(this: any): string {
       const {
         gitSha,
       } = this;

--- a/client/src/components/AboutDialog.vue
+++ b/client/src/components/AboutDialog.vue
@@ -12,6 +12,7 @@
         dark
         depressed
         large
+        tile
         v-on="on"
         >
         About Multinet

--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -30,6 +30,8 @@
       </v-btn>
     </v-toolbar>
 
+    <about-dialog />
+
     <WorkspaceDialog
       @created="addWorkspace"
     />
@@ -77,6 +79,7 @@
         </v-list-item>
       </v-hover>
     </v-list>
+
   </v-navigation-drawer>
 </template>
 
@@ -86,6 +89,7 @@ import Vue from 'vue';
 import api from '@/api';
 import WorkspaceDialog from '@/components/WorkspaceDialog.vue';
 import DeleteWorkspaceDialog from '@/components/DeleteWorkspaceDialog.vue';
+import AboutDialog from '@/components/AboutDialog.vue';
 
 interface CheckboxTable {
   [index: string]: boolean;
@@ -103,6 +107,7 @@ export default Vue.extend({
   components: {
     DeleteWorkspaceDialog,
     WorkspaceDialog,
+    AboutDialog,
   },
 
   computed: {

--- a/client/src/components/Sidebar.vue
+++ b/client/src/components/Sidebar.vue
@@ -17,6 +17,7 @@
           tag="button"
         >
           Multinet
+          <about-dialog />
         </router-link>
       </v-toolbar-title>
       <v-spacer />
@@ -29,8 +30,6 @@
         </v-avatar>
       </v-btn>
     </v-toolbar>
-
-    <about-dialog />
 
     <WorkspaceDialog
       @created="addWorkspace"

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const process = require('process');
 const path = require('path');
 const dotenv = require('dotenv');
+const webpack = require('webpack');
 
 const VuetifyLoaderPlugin = require('vuetify-loader/lib/plugin');
 
@@ -9,10 +10,20 @@ const VuetifyLoaderPlugin = require('vuetify-loader/lib/plugin');
 const env = dotenv.parse(fs.readFileSync(path.resolve('..', '.env')));
 process.env.FLASK_SERVE_PORT = process.env.FLASK_SERVE_PORT || env.FLASK_SERVE_PORT || 5000;
 
+// Look for a git-sha file; if found, inject the value found in it into the
+// application.
+let GIT_SHA = null;
+if (fs.existsSync('git-sha')) {
+  GIT_SHA = JSON.stringify(fs.readFileSync('git-sha').toString());
+}
+
 module.exports = {
   configureWebpack: {
     plugins: [
       new VuetifyLoaderPlugin(),
+      new webpack.DefinePlugin({
+        GIT_SHA,
+      }),
     ],
   },
   devServer: {

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -14,7 +14,7 @@ process.env.FLASK_SERVE_PORT = process.env.FLASK_SERVE_PORT || env.FLASK_SERVE_P
 // application.
 let GIT_SHA = null;
 if (fs.existsSync('git-sha')) {
-  GIT_SHA = JSON.stringify(fs.readFileSync('git-sha').toString());
+  GIT_SHA = JSON.stringify(fs.readFileSync('git-sha').toString().trim());
 }
 
 module.exports = {


### PR DESCRIPTION
This PR adds an "about multinet" panel, activated by a button in the sidebar. If, at build time, the top-level contains a file `git-sha`, the contents of that file will be injected into the about panel, giving us an easy way to verify which exact commit on GitHub was used to build a given deployment.

TODO:
- [x] find a better place for the "about" button (need @jtomeck's help for this)
- [x] update the deployment workflow to spit out a git-sha file before the build process