### PR TITLE
Use backticks to protect hyphens in table names

### DIFF
--- a/multinet/db.py
+++ b/multinet/db.py
@@ -313,7 +313,7 @@ def workspace_table_rows(
     """Stream the rows of a table in CSV form."""
 
     query = f"""
-    FOR d in {table}
+    FOR d in `{table}`
         LIMIT {offset}, {limit}
         RETURN d
     """
@@ -324,7 +324,7 @@ def workspace_table_rows(
 def workspace_table_row_count(workspace: str, table: str) -> int:
     """Return the number of rows in a table."""
     count_query = f"""
-    RETURN LENGTH({table})
+    RETURN LENGTH(`{table}`)
     """
     return next(aql_query(workspace, count_query))
 
@@ -335,7 +335,7 @@ def workspace_table_keys(
     """Get the keys of a table in a workspace."""
 
     query = f"""
-    FOR d in {table}
+    FOR d in `{table}`
         LIMIT 0, 1
         RETURN ATTRIBUTES(d)
     """
@@ -387,7 +387,7 @@ def graph_node(workspace: str, graph: str, table: str, node: str) -> dict:
         raise TableNotFound(workspace, table)
 
     query = f"""
-    FOR d in {table}
+    FOR d in `{table}`
       FILTER d._id == "{table}/{node}"
       RETURN d
     """
@@ -424,8 +424,9 @@ def graph_nodes(workspace: str, graph: str, offset: int, limit: int) -> GraphNod
 
     # Get the actual node data.
     node_tables = graph_node_tables(workspace, graph)
+    node_table_names = ", ".join(f"`{name}`" for name in node_tables)
     node_query = f"""
-    FOR c in [{", ".join(node_tables)}]
+    FOR c in [{node_table_names}]
       FOR d in c
         LIMIT {offset}, {limit}
         RETURN d
@@ -434,7 +435,7 @@ def graph_nodes(workspace: str, graph: str, offset: int, limit: int) -> GraphNod
 
     # Get the total node count.
     count_query = f"""
-    FOR c in [{", ".join(node_tables)}]
+    FOR c in [{node_table_names}]
       FOR d in c
         COLLECT WITH COUNT INTO count
         RETURN count
@@ -541,7 +542,7 @@ def node_edges(
 
     def query_text(filt: str) -> str:
         return f"""
-        FOR e IN {edge_table}
+        FOR e IN `{edge_table}`
             FILTER {filt}
             LIMIT {offset}, {limit}
             RETURN {{
@@ -553,7 +554,7 @@ def node_edges(
 
     def count_text(filt: str) -> str:
         return f"""
-        FOR e IN {edge_table}
+        FOR e IN `{edge_table}`
             FILTER {filt}
             COLLECT WITH COUNT INTO count
             RETURN count

--- a/test/test_aql_table_creation.py
+++ b/test/test_aql_table_creation.py
@@ -44,7 +44,7 @@ def test_existing_table(populated_workspace, managed_user, server):
     """Test that attempt to create a table with an existing name fails."""
     workspace, _, node_table, _ = populated_workspace
 
-    aql = f"FOR thing in {node_table} RETURN thing"
+    aql = f"FOR thing in `{node_table}` RETURN thing"
 
     with conftest.login(managed_user, server):
         resp = server.post(
@@ -61,7 +61,7 @@ def test_create_node_table(populated_workspace, managed_user, server):
     """Test that creating a node table succeeds."""
     workspace, _, node_table, edge_table = populated_workspace
 
-    aql = f"FOR doc in {node_table} RETURN doc"
+    aql = f"FOR doc in `{node_table}` RETURN doc"
     new_table_name = "new_table"
 
     with conftest.login(managed_user, server):
@@ -79,7 +79,7 @@ def test_create_edge_table(populated_workspace, managed_user, server):
     """Test that creating an edge table succeeds."""
     workspace, _, node_table, edge_table = populated_workspace
 
-    aql = f"FOR doc in {edge_table} RETURN doc"
+    aql = f"FOR doc in `{edge_table}` RETURN doc"
     new_table_name = "new_table"
 
     with conftest.login(managed_user, server):
@@ -97,7 +97,7 @@ def test_unsupported_table(populated_workspace, managed_user, server):
     """Test that creating a non edge/node table results in an error."""
     workspace, _, node_table, edge_table = populated_workspace
 
-    aql = f"FOR doc in {edge_table} RETURN {{ name: 'something' }}"
+    aql = f"FOR doc in `{edge_table}` RETURN {{ name: 'something' }}"
     new_table_name = "new_table"
 
     with conftest.login(managed_user, server):


### PR DESCRIPTION
I think I got all of them.

TODO:
- [ ] use bind vars (see https://github.com/multinet-app/multinet-server/issues/434#issuecomment-666523967)

Fixes #434
Depends on #436 